### PR TITLE
Switch to using underscores as consistent word separator.

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -1,5 +1,5 @@
 default['ros_buildfarm']['agent']['agent_username'] = 'jenkins-agent'
-default['ros_buildfarm']['agent']['java-args'] = ''
+default['ros_buildfarm']['agent']['java_args'] = ''
 default['ros_buildfarm']['agent']['username'] = ''
 default['ros_buildfarm']['agent']['password'] = ''
 default['ros_buildfarm']['agent']['nodename'] = ''

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,1 @@
-default['ros_buildfarm']['jenkins-url'] = ''
+default['ros_buildfarm']['jenkins_url'] = ''

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -55,9 +55,9 @@ package 'qemu-user-static'
 template '/etc/default/jenkins-agent' do
   source 'jenkins-agent.env.erb'
   variables Hash[
-    java_args: node['ros_buildfarm']['agent']['java-args'],
+    java_args: node['ros_buildfarm']['agent']['java_args'],
     jarfile: swarm_client_jarfile_path,
-    jenkins_url: node['ros_buildfarm']['jenkins-url'],
+    jenkins_url: node['ros_buildfarm']['jenkins_url'],
     username: node['ros_buildfarm']['agent']['username'],
     password: node['ros_buildfarm']['agent']['password'],
     name: node['ros_buildfarm']['agent']['nodename'],


### PR DESCRIPTION
I've been a bit haphazard in the use of dashes versus underscores as the
word separator. In general I prefer dashes (shoutout to languages
without infix operators which make multi-word identifiers unambiguous
when dash-separated) but, dashes are not recommended in chef
identifiers, cookbooks in particular. In order to to allow attribute
names to align with cookbook names and not worry about alternate
spellings let's just settle on using underscores to separate words and
I'll learn to live with it.

While I'm only applying this change to the in-development ros_buildfarm
cookbook at some point we should revisit the other cookbooks and update
the attributes.