### PR TITLE
Add an smtp server for jenkins

### DIFF
--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -2,4 +2,4 @@ default['ros_buildfarm']['jenkins']['timezone'] = 'America/Los_Angeles'
 default['ros_buildfarm']['jenkins']['auth_strategy'] = 'default'
 default['ros_buildfarm']['server_name'] = 'ros_buildfarm'
 default['ros_buildfarm']['admin_email'] = 'noreply@ros_buildfarm'
-
+default['ros_buildfarm']['smtp'] = false

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -24,6 +24,10 @@ suites:
     attributes:
   - name: jenkins
     data_bags_path: "test/integration/data_bags"
+    attributes:
+      ros_buildfarm:
+        smtp: true
+
     run_list:
       - recipe[ros_buildfarm::jenkins]
     verifier:

--- a/recipes/_jenkins_smtp.rb
+++ b/recipes/_jenkins_smtp.rb
@@ -1,0 +1,56 @@
+package 'postfix'
+package 'opendkim'
+package 'opendkim-tools'
+
+mail_name = node['ros_buildfarm']['server_name']
+file '/etc/mailname' do
+  content mail_name
+end
+template '/etc/postfix/main.cf' do
+  source 'postfix/main.cf.erb'
+  variables Hash[
+    hostname: mail_name
+  ]
+end
+
+dkim_config = data_bag_item('ros_buildfarm_dkim_configuration', node.chef_environment)
+
+directory "/etc/opendkim/keys/#{mail_name}" do
+  recursive true
+end
+dkim_config['keys'].each do |name, data|
+  file "/etc/opendkim/keys/#{mail_name}/#{name}.private" do
+    content data['private']
+    mode '0600'
+  end
+  file "/etc/opendkim/keys/#{mail_name}/#{name}.txt" do
+    content data['txt']
+    mode '0600'
+  end
+end
+
+trusted_hosts = dkim_config['trusted_hosts']
+unless trusted_hosts.include? mail_name
+  trusted_hosts << mail_name
+end
+file '/etc/opendkim/TrustedHosts' do
+  content trusted_hosts.join("\n")
+  mode '0644'
+end
+
+template '/etc/opendkim/KeyTable' do
+  source 'opendkim/keytable.erb'
+  variables Hash[
+    keys: dkim_config['keys'],
+    mail_name: mail_name,
+  ]
+  mode '0644'
+end
+
+signing_table_content = dkim_config['signing_entries'].map do |address, domainkey|
+  "#{address} #{domainkey}"
+end.join("\n")
+file '/etc/opendkim/SigningTable' do
+  content signing_table_content
+  mode '0644'
+end

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -253,4 +253,9 @@ node.default['ros_buildfarm']['agent']['executors'] = 1
 node.default['ros_buildfarm']['agent']['labels'] = %w(agent_on_master agent_on_jenkins)
 node.default['ros_buildfarm']['jenkins_url'] = 'http://localhost:8080/'
 
+## Postfix and OpenDKIM for SMTP
+if node['ros_buildfarm']['smtp']
+  include_recipe '::_jenkins_smtp'
+end
+
 include_recipe '::agent'

--- a/templates/opendkim/keytable.erb
+++ b/templates/opendkim/keytable.erb
@@ -1,0 +1,3 @@
+<% @keys.each do |name, data| -%>
+<%= name %>._domainkey.<%= @mail_name %>:<%= name %>:/etc/opendkim/keys<%= @mail_name %>/<%= name %>.private
+<% end -%>

--- a/templates/postfix/main.cf.erb
+++ b/templates/postfix/main.cf.erb
@@ -1,0 +1,36 @@
+<%# vim:ft=pfmain -%>
+smtpd_banner = $myhostname ESMTP $mail_name (Ubuntu)
+biff = no
+
+append_dot_mydomain = no
+readme_directory = no
+
+#TLS
+
+smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+smtpd_use_tls=yes
+smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
+smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+
+
+smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
+myhostname = <%= @hostname %>
+alias_maps = hash:/etc/aliases
+alias_database = hash:/etc/aliases
+myorigin  = /etc/mailname
+mydestination = build.ros2.org, localhost
+relayhost =
+mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
+mailbox_size_limit = 0
+recipient_delimiter = +
+inet_interfaces = all
+inet_protocols = all
+
+
+### DKIM
+
+milter_protocol = 2
+milter_default_action = accept
+smtpd_milters = inet:localhost:12301
+non_smtpd_milters = inet:localhost:12301

--- a/test/integration/data_bags/ros_buildfarm_dkim_configuration/test.json
+++ b/test/integration/data_bags/ros_buildfarm_dkim_configuration/test.json
@@ -1,0 +1,19 @@
+{
+	"id": "test",
+	"keys": {
+		"mail": {
+			"private": "dkim private key",
+			"txt": "dkim txt file"
+		}
+	},
+	"signing_entries": {
+		"*@build.ros2.org": "mail._domainkey.build.ros2.org"
+
+	},
+	"trusted_hosts": [
+		"127.0.0.1",
+		"localhost"
+	]
+}
+
+


### PR DESCRIPTION
This adds postfix for SMTP based on what we've been using for the ROS buildfarm over the past several years. I can't say I recommend this to anyone else. On our wishlist is to move to a mail service provider rather than administer an SMTP server solely for the buid farm operations.

Postfix is stable and reliable and my go to server for my personal mail domains but it's rather a lot of software to be running just to have a functional `sendmail` bin so I was originally planning to evaluate [opensmtpd](https://www.opensmtpd.org/) if we continue to need mail delivery on the host. I'd suggest anyone else who wants it to look there instead.