### PR TITLE
Fixes for acme.sh handling in jenkins.

### DIFF
--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -209,6 +209,7 @@ if node['ros_buildfarm']['letsencrypt_enabled']
   execute 'acme-issue-cert' do
     command %W(
       /root/.acme.sh/acme.sh --issue
+      --webroot /var/www/html
       --domain #{server_name}
       --fullchain-file #{cert_path}
       --key-file #{key_path}

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -214,6 +214,7 @@ if node['ros_buildfarm']['letsencrypt_enabled']
       --fullchain-file #{cert_path}
       --key-file #{key_path}
     )
+    not_if "test -d /root/.acme.sh/#{server_name}"
   end
 else
   template '/etc/nginx/sites-enabled/jenkins' do


### PR DESCRIPTION
This includes two fixes.

* Without a --webroot arg acme.sh fails since it requires a server method.

* Issuing a certificate without --force-renew causes an error and we are actually fine skipping this step if the domain is already configured. This is somewhat brittle and may need to be made more robust if our acme.sh config needs to change. But until we have a need it's hard to say how we should structure the chef logic.
