### PR TITLE
Update publish over ssh plugin config.

### DIFF
--- a/templates/jenkins/jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin.xml.erb
+++ b/templates/jenkins/jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin.xml.erb
@@ -8,7 +8,12 @@
       <secretPassword></secretPassword>
       <remoteRootDir><%= node['ros_buildfarm']['ssh_publisher']['repo_root_dir'] %></remoteRootDir>
       <port><%= node['ros_buildfarm']['ssh_publisher']['repo_port'] %></port>
-      <commonConfig class="jenkins.plugins.publish_over_ssh.BapSshCommonConfiguration" reference="../../jenkins.plugins.publish__over__ssh.BapSshHostConfiguration/commonConfig"/>
+      <commonConfig class="jenkins.plugins.publish_over_ssh.BapSshCommonConfiguration">
+        <secretPassword></secretPassword>
+        <key><%= @ssh_key %></key>
+        <keyPath></keyPath>
+        <disableAllExec>true</disableAllExec>
+      </commonConfig>
       <timeout><%= node['ros_buildfarm']['ssh_publisher']['repo_timeout'] %></timeout>
       <overrideKey>false</overrideKey>
       <disableExec>false</disableExec>
@@ -17,7 +22,12 @@
         <key></key>
         <keyPath></keyPath>
       </keyInfo>
+      <jumpHost></jumpHost>
+      <proxyType></proxyType>
+      <proxyHost></proxyHost>
       <proxyPort>0</proxyPort>
+      <proxyUser></proxyUser>
+      <proxyPassword></proxyPassword>
     </jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
     <jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
       <name>docs</name>
@@ -35,7 +45,12 @@
         <key></key>
         <keyPath></keyPath>
       </keyInfo>
+      <jumpHost></jumpHost>
+      <proxyType></proxyType>
+      <proxyHost></proxyHost>
       <proxyPort>0</proxyPort>
+      <proxyUser></proxyUser>
+      <proxyPassword></proxyPassword>
     </jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
     <jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
       <name>rosdistro_cache</name>
@@ -53,7 +68,12 @@
         <key></key>
         <keyPath></keyPath>
       </keyInfo>
+      <jumpHost></jumpHost>
+      <proxyType></proxyType>
+      <proxyHost></proxyHost>
       <proxyPort>0</proxyPort>
+      <proxyUser></proxyUser>
+      <proxyPassword></proxyPassword>
     </jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
     <jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
       <name>status_page</name>
@@ -71,14 +91,14 @@
         <key></key>
         <keyPath></keyPath>
       </keyInfo>
+      <jumpHost></jumpHost>
+      <proxyType></proxyType>
+      <proxyHost></proxyHost>
       <proxyPort>0</proxyPort>
+      <proxyUser></proxyUser>
+      <proxyPassword></proxyPassword>
     </jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
   </hostConfigurations>
-  <commonConfig>
-    <secretPassphrase></secretPassphrase>
-    <key><%= @ssh_key %></key>
-    <keyPath></keyPath>
-    <disableAllExec>true</disableAllExec>
-  </commonConfig>
+  <commonConfig reference="../hostConfigurations/jenkins.plugins.publish__over__ssh.BapSshHostConfiguration/commonConfig"/>
   <defaults class="jenkins.plugins.publish_over_ssh.options.SshPluginDefaults"/>
 </jenkins.plugins.publish__over__ssh.BapSshPublisherPlugin_-Descriptor>


### PR DESCRIPTION
This configuration wasn't working and has been updated to better match output after saving
config the main Jenkins config in the gui.

Due to the way Jenkins encrypts secrets there will always be some linenoise between Jenkins' saved copy of this file and ours but this way there is at least no structural differences and issues with the configuration in memory causing build failures have been resolved.