### PR TITLE
Remove deprecated config option.

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,6 @@ provisioner:
   name: chef_solo
   product_name: chef
   product_version: 15
-  require_chef_omnibus: 15
   solo_rb:
     environment: test
 


### PR DESCRIPTION
For a while test kitchen wouldn't work without this option even while
complaining to me that it is deprecated.

Since updating to the latest chef-workstation package the recommended
path is now working as it should.