### PR TITLE
Add jenkins user to docker group for rosdistro cache jobs.

### DIFF
--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -259,3 +259,9 @@ if node['ros_buildfarm']['smtp']
 end
 
 include_recipe '::agent'
+
+group 'docker' do
+  members ['jenkins']
+  append true
+  action :manage
+end


### PR DESCRIPTION
The rosdistro_cache jobs run in the in-process Jenkins executor which is running as the jenkins system user rather than jenkins-agent so it also needs to permission to work with docker.