### PR TITLE
Add gpg-vault service.

### DIFF
--- a/files/gpg-vault-agent.service
+++ b/files/gpg-vault-agent.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=GnuPG cryptographic agent and passphrase cache
+Documentation=man:gpg-agent(1)
+
+[Service]
+Type=forking
+User=gpg-vault
+ExecStart=/usr/bin/gpg-agent --daemon
+ExecStartPost=/bin/chmod ga+rw /var/run/gpg-vault/S.gpg-agent
+ExecReload=/usr/bin/gpgconf --reload gpg-agent
+
+[Install]
+WantedBy=default.target

--- a/files/repo/gpg-agent.conf
+++ b/files/repo/gpg-agent.conf
@@ -1,0 +1,1 @@
+extra-socket /var/run/gpg-vault/S.gpg-agent


### PR DESCRIPTION
This is the adaptation of @cottsay's work creating an isolated gpg-vault
user running a shareable gpg-agent session.

Implementation note:
For other systemd services we've been installing the unit file and
triggering systemctl-daemon-reload manually. I noticed that chef has a
systemd_unit resource [1] and decided to try and use that to bundle
triggering the reload along with starting and enabling the service.

I'm interested in whether others like it better or not. It bakes systemd
into our chef but so does manually executing systemctl commands.
Feedback welcome.

[1]: https://docs.chef.io/resources/systemd_unit