### PR TITLE
Install and configure rsync endpoints on the repo host.

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -2,3 +2,4 @@ default['ros_buildfarm']['apt_repos']['bootstrap_url'] = 'http://repos.ros.org/r
 default['ros_buildfarm']['apt_repos']['component'] = 'main'
 default['ros_buildfarm']['apt_repos']['architectures'] = %w[i386 amd64 arm64 armhf source]
 default['ros_buildfarm']['apt_repos']['suites'] = %w[xenial bionic focal stretch buster]
+default['ros_buildfarm']['repo']['rsyncd_endpoints'] = Hash[]

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -33,10 +33,19 @@ suites:
       inspec_tests:
         - test/integration/jenkins
   - name: repo
+    attributes:
+      ros_buildfarm:
+        repo:
+          rsyncd_endpoints:
+            ros-main:
+              comment: ROS apt repository
+              path: /var/repos/ubuntu/main
+            ros-testing:
+              comment: ROS apt testing repository
+              path: /var/repos/ubuntu/testing
     data_bags_path: "test/integration/data_bags"
     run_list:
       - recipe[ros_buildfarm::repo]
     verifier:
       inspec_tests:
         - test/integration/repo
-    attributes:

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -197,3 +197,18 @@ end
 service 'nginx' do
   action [:start, :enable]
 end
+
+# Configure rsync endpoints for repositories
+if not node['ros_buildfarm']['repo']['rsyncd_endpoints'].empty?
+  package 'rsync'
+  template '/etc/rsyncd.conf' do
+    source 'rsyncd.conf.erb'
+    variables Hash[
+      rsyncd_endpoints: node['ros_buildfarm']['repo']['rsyncd_endpoints']
+    ]
+    notifies :restart, 'service[rsync]'
+  end
+  service 'rsync' do
+    action [:start, :enable]
+  end
+end

--- a/templates/rsyncd.conf.erb
+++ b/templates/rsyncd.conf.erb
@@ -1,0 +1,5 @@
+<% @rsyncd_endpoints.each do |name, data| -%>
+[<%= name %>]
+  comment = <%= data['comment'] %>
+  path = <%= data['path'] %>
+<% end -%>


### PR DESCRIPTION
This allows us to configure the rsync endpoints used by the canonical
buildfarm and should be expandable to the rpm repositories once they're
ready.