### PR TITLE
Remove analysis-core (EOL) and ssl email-ext from CasC

### DIFF
--- a/attributes/plugins.rb
+++ b/attributes/plugins.rb
@@ -1,7 +1,6 @@
 default['ros_buildfarm']['jenkins']['plugins'] = {
   "PrioritySorter" => "3.6.0",
   "ace-editor" => "1.1",
-  "analysis-core" => "1.96",
   "analysis-model-api" => "8.0.1",
   "ant" => "1.9",
   "antisamy-markup-formatter" => "1.5",

--- a/templates/jenkins/jenkins.yaml.erb
+++ b/templates/jenkins/jenkins.yaml.erb
@@ -158,7 +158,6 @@ unclassified:
     maxAttachmentSize: -1
     maxAttachmentSizeMb: 0
     precedenceBulk: false
-    useSsl: false
     watchingEnabled: false
   ghprbTrigger:
     extensions:

--- a/templates/jenkins/jenkins.yaml.erb
+++ b/templates/jenkins/jenkins.yaml.erb
@@ -175,10 +175,6 @@ unclassified:
     globalConfigName: "jenkins"
     showEntireCommitSummaryInChanges: false
     useExistingAccountWithSameEmail: false
-  globalSettings:
-    failOnCorrupt: false
-    noAuthors: false
-    quietMode: false
   location:
     adminAddress: "<%= @admin_email %>"
     url: "<%= @scheme %>://<%= @server_name %>"


### PR DESCRIPTION
Part of refactor from #18

- Remove analysis-core from plugin list. EOL
- Remove useSsl (email-ext) from CasC

Found them needed to make github actions CI to work.
