### PR TITLE
Use upstream Jenkins cookbook.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,4 +5,4 @@ source 'https://supermarket.chef.io'
 metadata
 
 # TODO: Update to a released cookbook version once the auth retry is upstream.
-cookbook "jenkins", github: "nuclearsandwich/jenkins", branch: 'http-auth-retry'
+cookbook "jenkins", ">= 8.0.4"


### PR DESCRIPTION
We were using a fork in order to get a fix that I made previously but
that fix is now integrated into upstream in version 8.0.4.