### PR TITLE
Disable CRI plugin for containerd.

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -1,5 +1,16 @@
 apt_update
 package 'docker.io'
+service 'docker' do
+  action [:start, :enable]
+end
+service 'containerd' do
+  action :nothing
+end
+directory '/etc/containerd'
+file '/etc/containerd/config.toml' do
+  content 'disabled_plugins = ["cri"]'
+  notifies :restart, 'service[containerd]'
+end
 
 agent_username = node['ros_buildfarm']['agent']['agent_username']
 agent_homedir = "/home/#{agent_username}"


### PR DESCRIPTION
This service isn't used by the ROS build farm and running it presents
opportunities to interfere with running containers.