### PR TITLE
Improved reverse proxy configuration for Jenkins

### DIFF
--- a/templates/nginx/jenkins-webproxy.http.conf.erb
+++ b/templates/nginx/jenkins-webproxy.http.conf.erb
@@ -1,6 +1,7 @@
 # Establish the local jenkins server as an upstream
 # application server.
 upstream jenkins {
+	keepalive 32;
 	# Disable timeouts waiting for the Jenkins backend.  Jenkins requests can
 	# take foreeeeevvverrrr and we should just wait for them to complete.
 	server 127.0.0.1:8080 fail_timeout=0;
@@ -11,13 +12,23 @@ server {
 	listen 80 default_server;
 	server_name <%= @server_name %>;
 
+        # Pass through jenkins headers nginx may consider invalid.
+        ignore_invalid_headers off;
+
 	location / {
+		# https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-nginx/
+		sendfile off;
+		client_max_body_size 10m;
+		client_body_buffer_size 128k;
 		proxy_set_header Host $host:$server_port;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_redirect http:// https://;
 		proxy_buffering off;
+		proxy_request_buffering off;
+		proxy_connect_timeout 120s;
+		proxy_send_timeout 120s;
 		proxy_read_timeout 180s;
 		proxy_pass http://jenkins;
 	}

--- a/templates/nginx/jenkins-webproxy.http.conf.erb
+++ b/templates/nginx/jenkins-webproxy.http.conf.erb
@@ -18,6 +18,7 @@ server {
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_redirect http:// https://;
 		proxy_buffering off;
+		proxy_read_timeout 180s;
 		proxy_pass http://jenkins;
 	}
 }

--- a/templates/nginx/jenkins-webproxy.ssl.conf.erb
+++ b/templates/nginx/jenkins-webproxy.ssl.conf.erb
@@ -57,6 +57,7 @@ server {
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_redirect http:// https://;
 		proxy_buffering off;
+		proxy_read_timeout 180s;
 		proxy_pass http://jenkins;
 	}
 }

--- a/templates/nginx/jenkins-webproxy.ssl.conf.erb
+++ b/templates/nginx/jenkins-webproxy.ssl.conf.erb
@@ -1,6 +1,7 @@
 # Establish the local jenkins server as an upstream
 # application server.
 upstream jenkins {
+	keepalive 32;
 	# Disable timeouts waiting for the Jenkins backend.  Jenkins requests can
 	# take foreeeeevvverrrr and we should just wait for them to complete.
 	server 127.0.0.1:8080 fail_timeout=0;
@@ -42,6 +43,8 @@ server {
 
 	ssl_certificate <%= @cert_path %>;
 	ssl_certificate_key <%= @key_path %>;
+        # Pass through jenkins headers nginx may consider invalid.
+        ignore_invalid_headers off;
 
 	# Allow ACME challenge to access the webroot directly.
 	location '/.well-known/acme-challenge' {
@@ -51,12 +54,19 @@ server {
 	}
 
 	location / {
+		# https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-nginx/
+		sendfile off;
+		client_max_body_size 10m;
+		client_body_buffer_size 128k;
 		proxy_set_header Host $host:$server_port;
 		proxy_set_header X-Real-IP $remote_addr;
 		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 		proxy_set_header X-Forwarded-Proto $scheme;
 		proxy_redirect http:// https://;
 		proxy_buffering off;
+		proxy_request_buffering off;
+		proxy_connect_timeout 120s;
+		proxy_send_timeout 120s;
 		proxy_read_timeout 180s;
 		proxy_pass http://jenkins;
 	}


### PR DESCRIPTION
The Jenkins project recommends some configuration directives for reverse proxying Jenkins: https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-nginx/

I've applied those verbatim but further increased some of the timeouts based on experience with our large farms.