### PR TITLE
Fix typo in default executors attribute name.

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -3,6 +3,5 @@ default['ros_buildfarm']['agent']['java_args'] = ''
 default['ros_buildfarm']['agent']['username'] = 'admin'
 default['ros_buildfarm']['agent']['nodename'] = 'agent'
 default['ros_buildfarm']['agent']['description'] = 'build agent'
-default['ros_buildfarm']['agent']['executor'] = 4
+default['ros_buildfarm']['agent']['executors'] = 4
 default['ros_buildfarm']['agent']['labels'] = %w(buildagent)
-


### PR DESCRIPTION
Since we override the executor count in several places this wasn't noticed immediately.