### PR TITLE
Fixes and improvements for upload triggers.

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -59,7 +59,7 @@ cookbook_file "/home/#{agent_username}/upload_triggers/upload_repo.bash" do
   mode '0700'
 end
 data_bag('ros_buildfarm_upload_keys').each do |id|
-  key = data_bag_item('ros_buildfarm_upload_keys', id)
+  key = data_bag_item('ros_buildfarm_upload_keys', id)[node.chef_environment]
   file "/home/#{agent_username}/upload_triggers/#{key['name']}" do
     content key['content']
     owner agent_username

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -66,6 +66,11 @@ data_bag('ros_buildfarm_upload_keys').each do |id|
     group agent_username
     mode '0600'
   end
+  if key['symlink']
+    link "/home/#{agent_username}/upload_triggers/#{key['symlink']}" do
+      to "/home/#{agent_username}/upload_triggers/#{key['name']}"
+    end
+  end
 end
 
 # Configure gpg-vault

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -52,7 +52,7 @@ directory "/home/#{agent_username}/upload_triggers" do
   group agent_username
 end
 # TODO: at some point this file will need to be templatized and only installed if needed.
-cookbook_file "/home/#{agent_username}/upload_repo.bash" do
+cookbook_file "/home/#{agent_username}/upload_triggers/upload_repo.bash" do
   source 'upload_repo.bash'
   owner agent_username
   group agent_username

--- a/test/integration/data_bags/ros_buildfarm_upload_keys/main.json
+++ b/test/integration/data_bags/ros_buildfarm_upload_keys/main.json
@@ -1,6 +1,8 @@
 {
-	"id": "testing",
-	"name": "testing",
-	"content": "Example key contents",
-	"symlink": "ros-shadow-fixed-id"
+  "test": {
+    "id": "testing",
+    "name": "testing",
+    "content": "Example key contents",
+    "symlink": "ros-shadow-fixed-id"
+  }
 }

--- a/test/integration/data_bags/ros_buildfarm_upload_keys/main.json
+++ b/test/integration/data_bags/ros_buildfarm_upload_keys/main.json
@@ -1,5 +1,6 @@
 {
 	"id": "testing",
 	"name": "testing",
-	"content": "Example key contents"
+	"content": "Example key contents",
+	"symlink": "ros-shadow-fixed-id"
 }

--- a/test/integration/data_bags/ros_buildfarm_upload_keys/testing.json
+++ b/test/integration/data_bags/ros_buildfarm_upload_keys/testing.json
@@ -1,5 +1,7 @@
 {
-	"id": "main",
-	"name": "main",
-	"content": "Example key contents"
+  "test": {
+    "id": "main",
+    "name": "main",
+    "content": "Example key contents"
+  }
 }


### PR DESCRIPTION
The upload jobs are only used by build.ros.org and build.ros2.org since their sole purpose is triggering an rsync on packages.ros.org to update from the build farm repository. As a result there were some issues that weren't found until the production deployment of build.ros2.org.
Additionally in anticipation of deploying build.ros.org I've scoped the ros_buildfarm_upload_keys data bag to be environment-specific since the two farms use different keys.