### PR TITLE
Nest Jenkins attributes under a ['jenkins'] object and add warnings for old attribute hierarchy.

### DIFF
--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -1,5 +1,5 @@
 default['ros_buildfarm']['jenkins']['timezone'] = 'America/Los_Angeles'
 default['ros_buildfarm']['jenkins']['auth_strategy'] = 'default'
-default['ros_buildfarm']['server_name'] = 'ros_buildfarm'
-default['ros_buildfarm']['admin_email'] = 'noreply@ros_buildfarm'
+default['ros_buildfarm']['jenkins']['server_name'] = 'ros_buildfarm'
+default['ros_buildfarm']['jenkins']['admin_email'] = 'noreply@ros_buildfarm'
 default['ros_buildfarm']['smtp'] = false

--- a/recipes/_jenkins_smtp.rb
+++ b/recipes/_jenkins_smtp.rb
@@ -2,7 +2,7 @@ package 'postfix'
 package 'opendkim'
 package 'opendkim-tools'
 
-mail_name = node['ros_buildfarm']['server_name']
+mail_name = node['ros_buildfarm']['jenkins']['server_name']
 file '/etc/mailname' do
   content mail_name
 end

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -1,5 +1,31 @@
 ## Jenkins Server ##
 
+
+# Normalize attribute hierarchy
+# Some attributes were inconsistently nested in the ros_buildfarm cookbook.
+# The default and expected attributes have been changed but in order
+# to remain compatible with existing configurations a warning is being added
+# if the old attributes are set and differ from the new ones.
+%w(admin_email server_name).each do |attr|
+  if node['ros_buildfarm'][attr] # the old attribute is defined
+    if node['ros_buildfarm']['jenkins'][attr].nil?
+      Chef::Log.warn(
+        "The attribute `node['ros_buildfarm']['#{attr}']` is now `node['ros_buildfarm']['jenkins']['#{attr}']`. " +
+        "Support for the previous attribute may be removed in a future release of this cookbook. " +
+        "Replacing the `node['ros_buildfarm']['#{attr}']` attribute with `node['ros_buildfarm']['jenkins']['#{attr}']` is recommended."
+      )
+      node.default['ros_buildfarm']['jenkins'][attr] = node['ros_buildfarm'][attr]
+    elsif node['ros_buildfarm']['jenkins'][attr] != node['ros_buildfarm'][attr]
+      Chef::Log.warn(
+        "The attribute `node['ros_buildfarm']['#{attr}']` is now `node['ros_buildfarm']['jenkins']['#{attr}']`. " +
+        "Support for the previous attribute may be removed in a future release of this cookbook. " +
+        "Removing the `node['ros_buildfarm']['#{attr}']` attribute is recommended."
+      )
+      node.default['ros_buildfarm'][attr] = node['ros_buildfarm']['jenkins'][attr]
+    end
+  end
+end
+
 # Run an apt update if one hasn't been run in 24 hours (the default frequency).
 # Without this the recipe fails on AWS instances with empty apt caches.
 apt_update

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -167,7 +167,7 @@ file '/etc/nginx/sites-enabled/default' do
 end
 
 if node['ros_buildfarm']['letsencrypt_enabled']
-  server_name = node['ros_buildfarm']['server_name']
+  server_name = node['ros_buildfarm']['jenkins']['server_name']
   cert_path = "/etc/ssl/certs/#{server_name}/fullchain.pem"
   key_path = "/etc/ssl/private/#{server_name}.key"
 
@@ -185,7 +185,7 @@ if node['ros_buildfarm']['letsencrypt_enabled']
   template '/etc/nginx/sites-enabled/jenkins' do
     source 'nginx/jenkins-webproxy.ssl.conf.erb'
     variables Hash[
-      server_name: node['ros_buildfarm']['server_name'],
+      server_name: node['ros_buildfarm']['jenkins']['server_name'],
       cert_path: cert_path,
       key_path: key_path,
     ]
@@ -221,7 +221,7 @@ else
   template '/etc/nginx/sites-enabled/jenkins' do
     source 'nginx/jenkins-webproxy.http.conf.erb'
     variables Hash[
-      server_name: node['ros_buildfarm']['server_name']
+      server_name: node['ros_buildfarm']['jenkins']['server_name']
     ]
     notifies :restart, 'service[nginx]'
   end


### PR DESCRIPTION
This was done inconsistently in some resources and not others causing improper configuration.
Both of these attributes are specific to the jenkins recipe and so are nested under a jenkins object.

I've also attempted to pilot a warning system for how I'd like to propagate changes to expected attributes in the future.