### PR TITLE
Add secret_text_credentials data bag and use it for GitHub Pull Request Builder (Ghprb) plugin configuration.

### DIFF
--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -231,21 +231,21 @@ package 'python3-yaml'
 
 package 'docker.io'
 
-data_bag('ros_buildfarm_private_key_credentials').each do |item|
-  private_key_credential = data_bag_item('ros_buildfarm_private_key_credentials', item)
-  jenkins_private_key_credentials private_key_credential['id'] do
-    id private_key_credential['id']
-    description private_key_credential['description']
-    private_key private_key_credential['private_key']
-  end
-end
-
 data_bag('ros_buildfarm_password_credentials').each do |item|
   password_credential = data_bag_item('ros_buildfarm_password_credentials', item)
   jenkins_password_credentials password_credential['id'] do
     id password_credential['id']
     description password_credential['description']
     password password_credential['password']
+  end
+end
+
+data_bag('ros_buildfarm_private_key_credentials').each do |item|
+  private_key_credential = data_bag_item('ros_buildfarm_private_key_credentials', item)
+  jenkins_private_key_credentials private_key_credential['id'] do
+    id private_key_credential['id']
+    description private_key_credential['description']
+    private_key private_key_credential['private_key']
   end
 end
 

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -249,6 +249,15 @@ data_bag('ros_buildfarm_password_credentials').each do |item|
   end
 end
 
+data_bag('ros_buildfarm_secret_text_credentials').each do |item|
+  secret_text_credential = data_bag_item('ros_buildfarm_secret_text_credentials', item)
+  jenkins_secret_text_credentials secret_text_credential['id'] do
+    id secret_text_credential['id']
+    description secret_text_credential['description']
+    secret secret_text_credential['secret_text']
+  end
+end
+
 # Configure agent on jenkins
 # TODO: (nuclearsandwich) This is going to require re-organization to suite an all-in-one setup.
 node.default['ros_buildfarm']['agent']['nodename'] = 'agent_on_jenkins'

--- a/templates/jenkins/jenkins.yaml.erb
+++ b/templates/jenkins/jenkins.yaml.erb
@@ -166,8 +166,8 @@ unclassified:
         showMatrixStatus: false
   gitHubPluginConfig:
     configs:
-    - credentialsId: "TODO credential"
-    hookUrl: "http://<%= @server_name %>/github-webhook/"
+    - credentialsId: "github_pull_request_builder"
+    hookUrl: "<%= @scheme %>://<%= @server_name %>/github-webhook/"
   gitSCM:
     createAccountBasedOnEmail: false
     globalConfigEmail: "jenkins@build.ros.org"

--- a/test/integration/data_bags/ros_buildfarm_jenkins_users/chef.json
+++ b/test/integration/data_bags/ros_buildfarm_jenkins_users/chef.json
@@ -2,7 +2,7 @@
   "id": "chef",
   "username": "chef",
   "chef_user": true,
-  "password": "foobar123",
+  "password": "chef",
   "public_keys": [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN4OX3lNn6AA2LFQlctEPg7yodu1kL4D/LEAM2z+mOyz chefuser"
   ],

--- a/test/integration/data_bags/ros_buildfarm_password_credentials/password.json
+++ b/test/integration/data_bags/ros_buildfarm_password_credentials/password.json
@@ -1,0 +1,5 @@
+{
+  "id": "password",
+  "description": "A test password",
+  "password": "A test password"
+}

--- a/test/integration/data_bags/ros_buildfarm_private_key_credentials/private.json
+++ b/test/integration/data_bags/ros_buildfarm_private_key_credentials/private.json
@@ -1,5 +1,5 @@
 {
   "id": "private",
   "description": "a private key",
-  "private_key": "Not a real private key"
+  "private_key": "-----BEGIN RSA PUBLIC KEY-----\nMIGJAoGBAMQEEu72Tn1D8mZfUiGppAlZsmSabFaZmoNC+k9T4PaeVRrtKIM5ZPCr\nTYyzrNngIXfVodlOxoRrzCUlt7fhLRjB6p6DqlfXr74BdzMnnq+/5YTYDWDfWo3M\nCpMKFa1XIcjZ6x4uFx/CQhx/qOmvnibPlOOFa6MHRDh1hVFuXZ7BAgMBAAE=\n-----END RSA PUBLIC KEY-----\n"
 }

--- a/test/integration/data_bags/ros_buildfarm_private_key_credentials/private.json
+++ b/test/integration/data_bags/ros_buildfarm_private_key_credentials/private.json
@@ -1,0 +1,5 @@
+{
+  "id": "private",
+  "description": "a private key",
+  "private_key": "Not a real private key"
+}

--- a/test/integration/data_bags/ros_buildfarm_secret_text_credentials/secret_text_example.json
+++ b/test/integration/data_bags/ros_buildfarm_secret_text_credentials/secret_text_example.json
@@ -1,0 +1,5 @@
+{
+  "id": "secret_text_example",
+  "description": "example text credential",
+  "secret_text": "It's a secret to everyone"
+}


### PR DESCRIPTION
The Ghprb plugin uses the credential here even though I think the config section is meant to apply more generally to the github plugin. The jenkins recipe did not have support for secret text credentials yet so this PR adds that support in order to use it for Ghprb.