### PR TITLE
Purge fingerprints directory on reconfiguration.

### DIFF
--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -249,6 +249,31 @@ data_bag('ros_buildfarm_password_credentials').each do |item|
   end
 end
 
+# Remove Jenkins fingerprint files
+# Jenkins tracks the fingerprints of certain files so that different jobs may use different versions.
+# The chef credential resources do not seem idempotent in the face of existing credentials so when chef
+# is run and they are updated the fingerprint of the credential changes which causes an issue with jobs
+# using them.
+# I would like to find a more elegant solution, either of getting Jenkins to use the current version
+# if the fingerprinted file is missing or making the credential resources idemponent. I'm not sure
+# if that's possible however given that Jenkins will encrypt sensitive data with an instance-specific key.
+# For now we are clobbering the fingerprints directory and hoping we get away with it. Unfortunately
+# this requires yet another Jenkins restart
+service 'jenkins' do
+  action :stop
+end
+directory '/var/lib/jenkins/fingerprints' do
+  action :delete
+  recursive true
+end
+directory '/var/lib/jenkins/fingerprints' do
+  owner 'jenkins'
+  group 'jenkins'
+end
+service 'jenkins' do
+  action :start
+end
+
 # Configure agent on jenkins
 # TODO: (nuclearsandwich) This is going to require re-organization to suite an all-in-one setup.
 node.default['ros_buildfarm']['agent']['nodename'] = 'agent_on_jenkins'


### PR DESCRIPTION
Credential files are recreated on each chef run in a non-idempontent
fashion. This may just be a quirk of the cookbook or it could be a
Jenkins limitation due to the per-instance encryption of sensitive data.
Either way we live with it for now by unconditionally purging the
fingerprints directory.