### PR TITLE
Pin to version 8.0.4.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,4 +5,4 @@ source 'https://supermarket.chef.io'
 metadata
 
 # TODO: Update to a released cookbook version once the auth retry is upstream.
-cookbook "jenkins", ">= 8.0.4"
+cookbook "jenkins", "8.0.4"


### PR DESCRIPTION
The change introduced in 8.1.0 breaks the use of run_state supplied
usernames and passwords for CLI. I need to ticket the issue upstream but
I want to find out a bit more about why the change was introduced first.