### PR TITLE
Add Docker cleanup script.

### DIFF
--- a/files/docker-disk-cleanup.sh
+++ b/files/docker-disk-cleanup.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+available=$(df --output=avail -BG /var/lib/docker | awk '/[0-9]+G/ { print $1 + 0 }')
+if [ $available -le 55 ]; then
+	docker system prune --all --force
+fi

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -35,6 +35,15 @@ service 'docker' do
   action [:start, :enable]
 end
 
+cookbook_file '/root/docker-disk-cleanup.sh' do
+  mode '0755'
+end
+
+cron 'docker_disk_cleanup' do
+  time :hourly
+  command "/root/docker-disk-cleanup.sh"
+end
+
 agent_username = node['ros_buildfarm']['agent']['agent_username']
 agent_homedir = "/home/#{agent_username}"
 


### PR DESCRIPTION
This script is less smart than the old docker cleanup script but is also
a four line shell script. It will run on the hour and only clear docker
images when necessary.
As a tradeoff for simplicity it will clear everything that is not in
active use.