### PR TITLE
Add pulp client packages to agent.

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -85,6 +85,12 @@ end
   package vcspkg
 end
 
+# Client utilities for pulp content manager
+package "python3-pip"
+%w[pulp-rpm-client==3.8.0 pulpcore-client==3.8.1].each do |pulppkg|
+  execute "python3 -m pip install #{pulppkg}"
+end
+
 # TODO install this only on amd64?
 package 'qemu-user-static'
 jenkins_username = node['ros_buildfarm']['agent']['username']


### PR DESCRIPTION
These packages are used to connect to the pulp service.
There is no built in chef resource for python packages from pypi and the
options for python provider cookbooks seem quite stale in Chef
supermarket. With the use of exact versions the pip install command is
idempotent and pypi will uninstall any other versions of the package as
we update in the future.
As a result I think sticking with an execute resource rather than trying
to import a dependency is the way to go for now.