### PR TITLE
Use environment-specific private key credentials.

### DIFF
--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -268,8 +268,8 @@ end
 
 data_bag('ros_buildfarm_private_key_credentials').each do |item|
   private_key_credential = data_bag_item('ros_buildfarm_private_key_credentials', item)[node.chef_environment]
-  jenkins_private_key_credentials item do
-    id item
+  jenkins_private_key_credentials private_key_credential['name'] do
+    id private_key_credential['name']
     description private_key_credential['description']
     private_key private_key_credential['private_key']
   end

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -267,9 +267,9 @@ data_bag('ros_buildfarm_password_credentials').each do |item|
 end
 
 data_bag('ros_buildfarm_private_key_credentials').each do |item|
-  private_key_credential = data_bag_item('ros_buildfarm_private_key_credentials', item)
-  jenkins_private_key_credentials private_key_credential['id'] do
-    id private_key_credential['id']
+  private_key_credential = data_bag_item('ros_buildfarm_private_key_credentials', item)[node.chef_environment]
+  jenkins_private_key_credentials item do
+    id item
     description private_key_credential['description']
     private_key private_key_credential['private_key']
   end

--- a/test/integration/data_bags/ros_buildfarm_private_key_credentials/private.json
+++ b/test/integration/data_bags/ros_buildfarm_private_key_credentials/private.json
@@ -1,6 +1,7 @@
 {
   "id": "private",
   "test": {
+    "name": "jenkins-agent",
     "description": "a private key",
     "private_key": "-----BEGIN RSA PUBLIC KEY-----\nMIGJAoGBAMQEEu72Tn1D8mZfUiGppAlZsmSabFaZmoNC+k9T4PaeVRrtKIM5ZPCr\nTYyzrNngIXfVodlOxoRrzCUlt7fhLRjB6p6DqlfXr74BdzMnnq+/5YTYDWDfWo3M\nCpMKFa1XIcjZ6x4uFx/CQhx/qOmvnibPlOOFa6MHRDh1hVFuXZ7BAgMBAAE=\n-----END RSA PUBLIC KEY-----\n"
   }

--- a/test/integration/data_bags/ros_buildfarm_private_key_credentials/private.json
+++ b/test/integration/data_bags/ros_buildfarm_private_key_credentials/private.json
@@ -1,5 +1,7 @@
 {
   "id": "private",
-  "description": "a private key",
-  "private_key": "-----BEGIN RSA PUBLIC KEY-----\nMIGJAoGBAMQEEu72Tn1D8mZfUiGppAlZsmSabFaZmoNC+k9T4PaeVRrtKIM5ZPCr\nTYyzrNngIXfVodlOxoRrzCUlt7fhLRjB6p6DqlfXr74BdzMnnq+/5YTYDWDfWo3M\nCpMKFa1XIcjZ6x4uFx/CQhx/qOmvnibPlOOFa6MHRDh1hVFuXZ7BAgMBAAE=\n-----END RSA PUBLIC KEY-----\n"
+  "test": {
+    "description": "a private key",
+    "private_key": "-----BEGIN RSA PUBLIC KEY-----\nMIGJAoGBAMQEEu72Tn1D8mZfUiGppAlZsmSabFaZmoNC+k9T4PaeVRrtKIM5ZPCr\nTYyzrNngIXfVodlOxoRrzCUlt7fhLRjB6p6DqlfXr74BdzMnnq+/5YTYDWDfWo3M\nCpMKFa1XIcjZ6x4uFx/CQhx/qOmvnibPlOOFa6MHRDh1hVFuXZ7BAgMBAAE=\n-----END RSA PUBLIC KEY-----\n"
+  }
 }


### PR DESCRIPTION
Private key credentials were not previously using environment-specific credentials but they should be.

This also adds an explicit name field since the credential name may not match the data bag ID.