### PR TITLE
Store Jenkins token in a file rather than environment

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,4 +1,6 @@
 ---
+driver:
+  vagrant
 provisioner:
   name: chef_solo
   product_name: chef
@@ -21,6 +23,8 @@ suites:
       inspec_tests:
         - test/integration/agent
     attributes:
+      ros_buildfarm:
+        jenkins_url: 'http://ros_buildfarm:8080'
   - name: jenkins
     data_bags_path: "test/integration/data_bags"
     attributes:

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -106,6 +106,7 @@ end
 
 # TODO install this only on amd64?
 package 'qemu-user-static'
+
 jenkins_username = node['ros_buildfarm']['agent']['username']
 agent_jenkins_user = search('ros_buildfarm_jenkins_users', "username:#{jenkins_username}").first
 template '/etc/default/jenkins-agent' do
@@ -115,7 +116,6 @@ template '/etc/default/jenkins-agent' do
     jarfile: swarm_client_jarfile_path,
     jenkins_url: node['ros_buildfarm']['jenkins_url'],
     username: jenkins_username,
-    password: agent_jenkins_user['password'],
     name: node['ros_buildfarm']['agent']['nodename'],
     description: node['ros_buildfarm']['agent']['description'],
     executors: node['ros_buildfarm']['agent']['executors'],
@@ -123,6 +123,13 @@ template '/etc/default/jenkins-agent' do
     labels: node['ros_buildfarm']['agent']['labels'],
   ]
   notifies :restart, 'service[jenkins-agent]'
+end
+directory '/etc/jenkins-agent'
+file '/etc/jenkins-agent/token' do
+  content agent_jenkins_user['password']
+  mode '0640'
+  owner 'root'
+  group 'jenkins-agent'
 end
 
 template '/etc/systemd/system/jenkins-agent.service' do

--- a/templates/jenkins-agent.env.erb
+++ b/templates/jenkins-agent.env.erb
@@ -5,7 +5,6 @@ SWARM_CLIENT_JAR='<%= @jarfile %>'
 JENKINS_URL='<%= @jenkins_url %>'
 
 USERNAME='<%= @username %>'
-PASSWORD='<%= @password %>'
 
 NAME='<%= @name %>'
 DESCRIPTION='<%= @description %>'

--- a/templates/jenkins-agent.service.erb
+++ b/templates/jenkins-agent.service.erb
@@ -6,7 +6,7 @@ After=network.target
 EnvironmentFile=/etc/default/<%= @service_name %>
 Type=simple
 ExecStart=/bin/sh -c "/usr/bin/java $JAVA_ARGS -jar $SWARM_CLIENT_JAR \
--master $JENKINS_URL -username $USERNAME -password \"$PASSWORD\" \
+-master $JENKINS_URL -username $USERNAME -passwordFile /etc/jenkins-agent/token \
 -name $NAME -description \"$DESCRIPTION\" -mode $MODE -executors $EXECUTORS \
 -fsroot $FSROOT -labels \"$LABELS\" $JENKINS_ARGS"
 


### PR DESCRIPTION
Reduce the ease with which a Jenkins token may be captured by a
malicious Jenkins job.
Additional measures should be taken:
1. Use a Jenkins user which only has the necessary permissions for agent
creation and configuration and not full admin access.
2. Restrict Jenkins agent connections to trusted networks.
3. Switch to a Jenkins API token rather than password to prevent a
captured token from being used to authenticate via the Jenkins web UI.