### PR TITLE
Use xslt to customize autoindex pages.

### DIFF
--- a/files/nginx/autoindex.xsl
+++ b/files/nginx/autoindex.xsl
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:param name="title"/>
+	<xsl:template match="/">
+		<html>
+			<head>
+				<title><xsl:value-of select="$title"/></title>
+				<style>
+					table { font-size: 1.5em; font-family: monospace; }
+					td { min-width: 16em; }
+				</style>
+			</head>
+			<body>
+				<h2><xsl:value-of select="$title"/></h2>
+				<hr/>
+				<table>
+					<xsl:if test="not($title = 'Index of /')"><a href=".. (Parent Directory)">..</a></xsl:if>
+					<xsl:for-each select="/list/directory">
+						<tr>
+							<td><a>
+									<xsl:attribute name="href"><xsl:value-of select="."/>/</xsl:attribute>
+									<xsl:value-of select="."/>/</a></td>
+							<td><xsl:value-of select="@mtime"/></td>
+							<td>
+								<xsl:if test="boolean(@size)"><xsl:value-of select="@size"/></xsl:if>
+								<xsl:if test="not(boolean(@size))">—</xsl:if>
+							</td>
+						</tr>
+					</xsl:for-each>
+					<xsl:for-each select="/list/file">
+						<tr>
+							<td><a>
+									<xsl:attribute name="href"><xsl:value-of select="."/></xsl:attribute>
+									<xsl:value-of select="."/></a></td>
+							<td><xsl:value-of select="@mtime"/></td>
+							<td>
+								<xsl:if test="boolean(@size)"><xsl:value-of select="@size"/></xsl:if>
+								<xsl:if test="not(boolean(@size))">—</xsl:if>
+							</td>
+						</tr>
+					</xsl:for-each>
+				</table>
+				<hr/>
+			</body>
+		</html>
+	</xsl:template>
+</xsl:stylesheet>
+
+

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -523,6 +523,10 @@ template '/etc/nginx/sites-available/repo' do
   ]
   notifies :restart, 'service[nginx]'
 end
+cookbook_file '/etc/nginx/autoindex.xsl' do
+  source 'nginx/autoindex.xsl'
+  notifies :restart, 'service[nginx]'
+end
 link '/etc/nginx/sites-enabled/default' do
   action :delete
   notifies :restart, 'service[nginx]'

--- a/templates/nginx/repo.conf.erb
+++ b/templates/nginx/repo.conf.erb
@@ -5,6 +5,8 @@ server {
 
 	location / {
 		autoindex on;
+		autoindex_format xml;
+		xslt_stylesheet /etc/nginx/autoindex.xsl title='Index%20of%20$uri';
 		index index.html;
 	}
 


### PR DESCRIPTION
The default nginx autoindex listing has hard length limits on the displayed files. This is a basic recreation of it without limits on the file length.