### PR TITLE
Use gpg -K to initialize the GNUPGHOME

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -81,9 +81,9 @@ end
 execute 'gpg-init' do
   command 'gpg -K'
   environment 'HOME' => '/home/gpg-vault'
-  not_if { File.directory? '/home/gpg-vault/.gnupg' }
   user 'gpg-vault'
   group 'gpg-vault'
+  creates '/home/gpg-vault/.gnupg'
 end
 cookbook_file '/home/gpg-vault/.gnupg/gpg-agent.conf' do
   source 'repo/gpg-agent.conf'
@@ -136,10 +136,12 @@ end
 
 # Configure GPG for reprepro
 # .gnupg/gpg.conf
-directory "/home/#{agent_username}/.gnupg" do
-  owner agent_username
+execute 'gpg-init' do
+  command 'gpg -K'
+  environment 'HOME' => "/home/#{agent_username}"
+  user agent_username
   group agent_username
-  mode '0700'
+  creates "/home/#{agent_username}/.gnupg"
 end
 cookbook_file "/home/#{agent_username}/.gnupg/gpg.conf" do
   source 'gpg.conf'


### PR DESCRIPTION
Also use the ['creates' syntax](https://docs.chef.io/resources/execute/#properties) for expressing that the command creates a file (directory).

This will ensure that the rest of the GnuPG files are created along with the `.gnupg` directory, all with the correct permissions.