### PR TITLE
Use gpg.conf for the gpg-vault as well

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -85,6 +85,12 @@ execute 'gpg-init' do
   user 'gpg-vault'
   group 'gpg-vault'
 end
+cookbook_file '/home/gpg-vault/.gnupg/gpg.conf' do
+  source 'gpg.conf'
+  owner 'gpg-vault'
+  group 'gpg-vault'
+  mode '0600'
+end
 cookbook_file '/home/gpg-vault/.gnupg/gpg-agent.conf' do
   source 'repo/gpg-agent.conf'
   owner 'gpg-vault'


### PR DESCRIPTION
This will help ensure uniform behavior among our GPG actors.