### PR TITLE
Add new 'group_execute' resource

### DIFF
--- a/libraries/group_execute_provider.rb
+++ b/libraries/group_execute_provider.rb
@@ -1,0 +1,28 @@
+class Chef
+  class Provider
+    class GroupExecute < Chef::Provider::Execute
+      provides :group_execute
+
+      def_delegators :secondary_groups
+
+      private
+
+      def command
+        command = new_resource.command
+
+        if new_resource.secondary_groups
+          groups = new_resource.secondary_groups
+          if group
+            # Always do the 'primary' group last in the call chain
+            groups = [group] + groups
+          end
+          groups.each do |secondary_group|
+            command = "sg #{secondary_group} #{Shellwords.shellescape(command)}"
+          end
+        end
+
+        command
+      end
+    end
+  end
+end

--- a/libraries/group_execute_provider.rb
+++ b/libraries/group_execute_provider.rb
@@ -14,7 +14,7 @@ class Chef
           groups = new_resource.secondary_groups
           if group
             # Always do the 'primary' group last in the call chain
-            groups = groups + [group]
+            groups << group
           end
           groups.reverse.each do |secondary_group|
             command = "sg #{secondary_group} #{Shellwords.shellescape(command)}"

--- a/libraries/group_execute_provider.rb
+++ b/libraries/group_execute_provider.rb
@@ -14,9 +14,9 @@ class Chef
           groups = new_resource.secondary_groups
           if group
             # Always do the 'primary' group last in the call chain
-            groups = [group] + groups
+            groups = groups + [group]
           end
-          groups.each do |secondary_group|
+          groups.reverse.each do |secondary_group|
             command = "sg #{secondary_group} #{Shellwords.shellescape(command)}"
           end
         end

--- a/libraries/group_execute_resource.rb
+++ b/libraries/group_execute_resource.rb
@@ -1,0 +1,11 @@
+class Chef
+  class Resource
+    class GroupExecute < Chef::Resource::Execute
+      provides :group_execute, target_mode: true
+
+      def secondary_groups(arg=nil)
+        set_or_return(:secondary_groups, arg, :kind_of => Array)
+      end
+    end
+  end
+end

--- a/libraries/group_execute_resource.rb
+++ b/libraries/group_execute_resource.rb
@@ -3,6 +3,10 @@ class Chef
     class GroupExecute < Chef::Resource::Execute
       provides :group_execute, target_mode: true
 
+      def command(arg=nil)
+        set_or_return(:command, arg, :kind_of => String)
+      end
+
       def secondary_groups(arg=nil)
         set_or_return(:secondary_groups, arg, :kind_of => Array)
       end


### PR DESCRIPTION
The Chef 'execute' resource allows you to specify user and group permissions with which to execute the command. Unfortunately, this doesn't take into account seccondary groups listed in /etc/group.

We're currently using those seccondary groups to enable a user (process) to access the GPG vault, and the reprepro commands invoked by chef will need to perform some signing, and will therefore need permission.

The new resource defined by this change is nearly identical to the 'execute' resource, but adds an additional 'seccondary_groups' property. The resource then augments the supplied command by prefixing it with calls to 'sg <group-name>' to chain through the given groups. If a 'group' value was specified by the resource, that group is added to the call chain last to ensure it is the primary group after the other groups have been added.

Some examples, assuming that `jenkins-agent` is a member of the `gpg-vault` group:

A normal `execute` invocation:
```
execute 'id' do
  user 'jenkins-agent'
  group 'jenkins-agent'
end
```
Result: `uid=1001(jenkins-agent) gid=1001(jenkins-agent) groups=1001(jenkins-agent),0(root)`

An invocation using `group_execute`:
```
group_execute 'id' do
  user 'jenkins-agent'
  group 'jenkins-agent'
  secondary_groups ['gpg-vault']
end
```
Result: `uid=1001(jenkins-agent) gid=1001(jenkins-agent) groups=1001(jenkins-agent),0(root),997(gpg-vault)`
The actual command invoked is: `sg gpg-vault sg\ jenkins-agent\ id`