### PR TITLE
Configure jenkins-agent to use the GPG vault

### DIFF
--- a/files/gpg.conf
+++ b/files/gpg.conf
@@ -1,2 +1,3 @@
 cert-digest-algo SHA256
 digest-algo SHA256
+no-autostart


### PR DESCRIPTION
This change drops the private keys from the jenkins-agent user and configures the user to utilize the GPG vault for signing operations.

The change to `gpg.conf` should prevent most of the GnuPG tools from automatically starting a new gpg-agent process, which should minimize the chances of accidentally overwriting the `S.gpg-agent` symbolic link with a new socket.

Requires #54