### PR TITLE
Grant the 'pulp' user access to gpg-vault

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -285,9 +285,9 @@ end
 
 execute 'gpg-init' do
   command 'gpg -K'
-  env 'HOME' => '/home/pulp'
   user 'pulp'
   group 'pulp'
+  environment 'HOME' => '/home/pulp'
   creates '/home/pulp/.gnupg'
 end
 cookbook_file '/home/pulp/.gnupg/gpg.conf' do


### PR DESCRIPTION
There are two things about the pulp user's access that differ from how things are set up for reprepro (in the jenkins-agent user):
1. There isn't a symlink for the gpg-agent socket because we want to invoke the signing operations in docker, where we need to specifically mount the socket anyway.
2. Pulp requires that we mark the public key we're going to sign with as 'trusted'.