### PR TITLE
Add upgrade path which removes previously deployed key

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -155,7 +155,7 @@ execute "(echo y) | gpg --command-fd 0 --no-tty --yes --delete-secret-keys #{gpg
   group agent_username
   environment 'HOME' => "/home/#{agent_username}"
   only_if { ::File.exist?("/home/#{agent_username}/.ssh/gpg_private_key.sec") }
-  only_if "gpg --list-secret-keys #{gpg_key['fingerprint']}"
+  only_if "test -f /home/#{agent_username}/.ssh/gpg_private_key.sec && gpg --list-secret-keys #{gpg_key['fingerprint']}"
 end
 execute "gpgconf --kill gpg-agent" do
   user agent_username


### PR DESCRIPTION
Everything is keyed off from the presence of the private key file on disk. The path is largely skipped if that file has already been removed.

I tested converging this change both with and after #55.