### PR TITLE
Don't proxy nonexistent pulp services

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -555,7 +555,7 @@ package 'nginx'
 template '/etc/nginx/sites-available/repo' do
   source 'nginx/repo.conf.erb'
   variables Hash[
-    rpm_repos: node['ros_buildfarm']['rpm_repos']
+    rpm_repos: (node['ros_buildfarm']['repo']['enable_pulp_services'] ? node['ros_buildfarm']['rpm_repos'] : [])
   ]
   notifies :restart, 'service[nginx]'
 end


### PR DESCRIPTION
If pulp services are disabled, even if RPM repositories are configured, we shouldn't create the proxy entries.