### PR TITLE
Fix the debug package URL for RPM repositories

### DIFF
--- a/templates/nginx/repo.conf.erb
+++ b/templates/nginx/repo.conf.erb
@@ -17,14 +17,14 @@ server {
 		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-SRPMS/;
 	}
 			<%- architectures.each do |arch| -%>
+	location /<%= dist %>/<%= version %>/<%= arch %>/debug/ {
+		# TODO more proxy_pass args
+		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-<%= arch %>-debug/;
+	}
+
 	location /<%= dist %>/<%= version %>/<%= arch %>/ {
 		# TODO more proxy_pass args
 		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-<%= arch %>/;
-	}
-
-	location /<%= dist %>/<%= version %>/<%= arch %>-debug/ {
-		# TODO more proxy_pass args
-		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-<%= arch %>-debug/;
 	}
 
 			<%- end -%>


### PR DESCRIPTION
The debug sub-repository is traditionally a subdirectory of the associated arch.

From what I can tell, nginx will process the location blocks in order of definition, so we want it to check the debug proxy first.