### PR TITLE
Fix the RPM repo proxy URLs

### DIFF
--- a/templates/nginx/repo.conf.erb
+++ b/templates/nginx/repo.conf.erb
@@ -12,17 +12,17 @@ server {
 
 	<%- @rpm_repos.each do |dist, versions| -%>
 		<%- versions.each do |version, architectures| -%>
-	location /<%= dist %>/<%= version %>/SRPMS/ {
+	location /<%= dist %>/building/<%= version %>/SRPMS/ {
 		# TODO more proxy_pass args
 		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-SRPMS/;
 	}
 			<%- architectures.each do |arch| -%>
-	location /<%= dist %>/<%= version %>/<%= arch %>/debug/ {
+	location /<%= dist %>/building/<%= version %>/<%= arch %>/debug/ {
 		# TODO more proxy_pass args
 		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-<%= arch %>-debug/;
 	}
 
-	location /<%= dist %>/<%= version %>/<%= arch %>/ {
+	location /<%= dist %>/building/<%= version %>/<%= arch %>/ {
 		# TODO more proxy_pass args
 		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-<%= arch %>/;
 	}


### PR DESCRIPTION
We specifically want to proxy only the 'building' repositories.

Requires #66