### PR TITLE
Drop explicit enable flag for Pulp

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -6,5 +6,4 @@ default['ros_buildfarm']['apt_repos']['suites'] = %w[xenial bionic focal stretch
 default['ros_buildfarm']['repo']['rsyncd_endpoints'] = Hash[]
 default['ros_buildfarm']['repo']['container_registry_cache_enabled'] = true
 default['ros_buildfarm']['repo']['pulp_worker_count'] = 2
-default['ros_buildfarm']['repo']['enable_pulp_services'] = true
 default['ros_buildfarm']['rpm_repos']['el']['7'] = %w[x86_64]

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -57,4 +57,4 @@ suites:
     attributes:
       ros_buildfarm:
         # pulp services cannot run due to docker-in-docker issues
-        rpm_repos: null
+        rpm_repos: {}

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -56,6 +56,5 @@ suites:
         - test/integration/repo
     attributes:
       ros_buildfarm:
-        repo:
-          # pulp services cannot run due to docker-in-docker issues
-          enable_pulp_services: false
+        # pulp services cannot run due to docker-in-docker issues
+        rpm_repos: null

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -57,4 +57,4 @@ suites:
     attributes:
       ros_buildfarm:
         # pulp services cannot run due to docker-in-docker issues
-        rpm_repos: {}
+        rpm_repos: null

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -386,7 +386,7 @@ cookbook_file "#{pulp_data_directory}/Dockerfile" do
   source 'pulp/Dockerfile'
 end
 
-if node['ros_buildfarm']['rpm_repos']
+if node['ros_buildfarm']['rpm_repos'] and not node['ros_buildfarm']['rpm_repos'].empty?
   execute 'docker build -t pulp_image .' do
     cwd pulp_data_directory
   end
@@ -555,7 +555,7 @@ package 'nginx'
 template '/etc/nginx/sites-available/repo' do
   source 'nginx/repo.conf.erb'
   variables Hash[
-    rpm_repos: node['ros_buildfarm']['rpm_repos']
+    rpm_repos: node['ros_buildfarm'] && node['ros_buildfarm']['rpm_repos'] || Hash[]
   ]
   notifies :restart, 'service[nginx]'
 end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -386,7 +386,7 @@ cookbook_file "#{pulp_data_directory}/Dockerfile" do
   source 'pulp/Dockerfile'
 end
 
-if node['ros_buildfarm']['repo']['enable_pulp_services']
+if node['ros_buildfarm']['rpm_repos']
   execute 'docker build -t pulp_image .' do
     cwd pulp_data_directory
   end


### PR DESCRIPTION
Instead, use the presence of RPM repository configurations to decide whether to deploy pulp services.

Closes #65