### PR TITLE
Restart jenkins-agent immediately on unit update

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -139,7 +139,7 @@ template '/etc/systemd/system/jenkins-agent.service' do
     username: agent_username,
   ]
   notifies :run, 'execute[systemctl-daemon-reload]', :immediately
-  notifies :restart, 'service[jenkins-agent]'
+  notifies :restart, 'service[jenkins-agent]', :immediately
 end
 
 execute 'systemctl-daemon-reload' do


### PR DESCRIPTION
It appears that allowing the delayed restart to run immediately after the service was started is causing it to fail occasionally.

This change issues a restart immediately after the unit file is created or updated (and after systemd reloads it). In the case where the unit was updated, the explicit 'start' is therefore a no-op. Otherwise, the service is started at that time.