### PR TITLE
Use 'rhel' in the repo name instead of 'el'

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -7,4 +7,4 @@ default['ros_buildfarm']['repo']['rsyncd_endpoints'] = Hash[]
 default['ros_buildfarm']['repo']['container_registry_cache_enabled'] = true
 default['ros_buildfarm']['repo']['pulp_worker_count'] = 2
 default['ros_buildfarm']['repo']['enable_pulp_services'] = true
-default['ros_buildfarm']['rpm_repos']['el']['7'] = %w[x86_64]
+default['ros_buildfarm']['rpm_repos']['rhel']['7'] = %w[x86_64]


### PR DESCRIPTION
We need to use `rhel` in the pulp repository names, not `el`, because `rhel` is what `ros_buildfarm` uses to identify RHEL.