### PR TITLE
Add optional username field to Jenkins password credentials.

### DIFF
--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -264,6 +264,7 @@ data_bag('ros_buildfarm_password_credentials').each do |item|
   jenkins_password_credentials password_credential['id'] do
     id password_credential['id']
     description password_credential['description']
+    username password_credential['username'] if password_credential['username']
     password password_credential['password']
   end
 end

--- a/test/integration/data_bags/ros_buildfarm_password_credentials/pulp_admin.json
+++ b/test/integration/data_bags/ros_buildfarm_password_credentials/pulp_admin.json
@@ -1,5 +1,6 @@
 {
   "id": "pulp_admin",
   "description": "password for pulp repository",
+  "username": "admin",
   "password": "look ma no hands"
 }


### PR DESCRIPTION
Since pulp needs one I used the pretend pulp cred as the test data bag for this.