### PR TITLE
Proxy all 3 repositories to Pulp, not just 'building'

### DIFF
--- a/templates/nginx/repo.conf.erb
+++ b/templates/nginx/repo.conf.erb
@@ -10,21 +10,22 @@ server {
 
 	<%- @rpm_repos.each do |dist, versions| -%>
 		<%- versions.each do |version, architectures| -%>
-	location /<%= dist %>/building/<%= version %>/SRPMS/ {
+			<%- %w(building testing main).each do |repo| -%>
+	location /<%= dist %>/<%= repo %>/<%= version %>/SRPMS/ {
 		# TODO more proxy_pass args
-		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-SRPMS/;
+		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-<%= repo %>-<%= dist %>-<%= version %>-SRPMS/;
 	}
 			<%- architectures.each do |arch| -%>
-	location /<%= dist %>/building/<%= version %>/<%= arch %>/debug/ {
+	location /<%= dist %>/<%= repo %>/<%= version %>/<%= arch %>/debug/ {
 		# TODO more proxy_pass args
-		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-<%= arch %>-debug/;
+		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-<%= repo %>-<%= dist %>-<%= version %>-<%= arch %>-debug/;
+	}
+	location /<%= dist %>/<%= repo %>/<%= version %>/<%= arch %>/ {
+		# TODO more proxy_pass args
+		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-<%= repo %>-<%= dist %>-<%= version %>-<%= arch %>/;
 	}
 
-	location /<%= dist %>/building/<%= version %>/<%= arch %>/ {
-		# TODO more proxy_pass args
-		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-<%= arch %>/;
-	}
-
+				<%- end -%>
 			<%- end -%>
 		<%- end -%>
 	<%- end -%>


### PR DESCRIPTION
Eventually we'd like to manifest the repositories as files-on-disk so that they can be rsync'd to mirrors, but for now, this is needed to unblock testing.