### PR TITLE
Add pulp_rsync content endpoint

### DIFF
--- a/files/pulp/Dockerfile
+++ b/files/pulp/Dockerfile
@@ -15,6 +15,7 @@ RUN dnf install \
   expat-devel \
   file-devel \
   gcc \
+  git \
   glib2-devel \
   libcurl-devel \
   libmodulemd-devel \
@@ -79,7 +80,7 @@ ENV PATH="/usr/local/lib/pulp/bin:${PATH}"
 ENV PYTHONPATH="/usr/local/lib/pulp/lib/python3.6/site-packages"
 
 RUN pip3 install scikit-build
-RUN pip3 install pulpcore==3.9.1 pulp-rpm==3.9.0
+RUN pip3 install pulpcore==3.9.1 pulp-rpm==3.9.0 git+https://github.com/cottsay/pulp_rsync.git@0.0.1
 RUN pip3 install --upgrade jsonschema
 
 ENV DJANGO_SETTINGS_MODULE="pulpcore.app.settings"


### PR DESCRIPTION
If you squint, it almost looks like an rsync implementation: https://github.com/cottsay/pulp_rsync

It's close enough for what we need it for.

To be clear, the idea is to use rsync to hydrate the local filesystem. I'm not planning to expose `pulp_rsync` to the interwebs.