### PR TITLE
Revert jenkins-agent to standalone GPG operation

### DIFF
--- a/files/gpg-vault.conf
+++ b/files/gpg-vault.conf
@@ -1,2 +1,3 @@
 cert-digest-algo SHA256
 digest-algo SHA256
+no-autostart


### PR DESCRIPTION
It appears that reprepro (or gpgme) misbehaves when configured in this way. Even though pulp has no problem with it, and I can't get gpgme to reproduce the same behavior, we're seeing reprepro fail to find the private key the majority of the time in production.

For now, let's revert to the previous behavior.

This reverts part of #63
This reverts part of #55