### PR TITLE
Add support for an RPM bootstrap repository

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -38,7 +38,7 @@ default['ros_buildfarm']['repo']['container_registry_cache_enabled'] = true
 default['ros_buildfarm']['repo']['pulp_worker_count'] = 2
 default['ros_buildfarm']['repo']['enable_pulp_services'] = true
 default['ros_buildfarm']['rpm_repos']['rhel']['8'] = %w[x86_64]
-default['ros_buildfarm']['rpm_bootstrap_repos']['rhel']['8'] = Hash[
+default['ros_buildfarm']['rpm_upstream_repos']['bootstrap']['rhel']['8'] = Hash[
   architectures: %w[x86_64],
   binary: 'http://repos.ros.org/repos/rhel/ros_bootstrap/8/$basearch/',
   debug: 'http://repos.ros.org/repos/rhel/ros_bootstrap/8/$basearch/debug/',

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -38,3 +38,9 @@ default['ros_buildfarm']['repo']['container_registry_cache_enabled'] = true
 default['ros_buildfarm']['repo']['pulp_worker_count'] = 2
 default['ros_buildfarm']['repo']['enable_pulp_services'] = true
 default['ros_buildfarm']['rpm_repos']['rhel']['8'] = %w[x86_64]
+default['ros_buildfarm']['rpm_bootstrap_repos']['rhel']['8'] = Hash[
+  architectures: %w[x86_64],
+  binary: 'http://repos.ros.org/repos/rhel/ros_bootstrap/8/$basearch/',
+  debug: 'http://repos.ros.org/repos/rhel/ros_bootstrap/8/$basearch/debug/',
+  source: 'http://repos.ros.org/repos/rhel/ros_bootstrap/8/SRPMS/'
+]

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -492,6 +492,66 @@ if node['ros_buildfarm']['repo']['enable_pulp_services']
     end
   end
 
+  # * Create bootstrap remotes
+  node['ros_buildfarm']['rpm_bootstrap_repos'].each do |dist, versions|
+    versions.each do |version, bootstrap_args|
+      repo_name = "ros-bootstrap-#{dist}-#{version}"
+
+      source_url = bootstrap_args['source']
+      execute "Create #{repo_name}-SRPMS" do
+        command %W[
+          python3
+          #{pulp_data_directory}/initialize.py
+          #{repo_name}-SRPMS
+          #{repo_name}-SRPMS
+          --upstream-repository=#{source_url}
+          --signing-service-name=#{gpg_key['fingerprint']}
+        ]
+        environment Hash[
+          "PULP_BASE_URL" => "http://127.0.0.1:24817",
+          "PULP_USERNAME" => "admin",
+          "PULP_PASSWORD" => pulp_admin_password,
+        ]
+      end
+
+      bootstrap_args['architectures'].each do |arch|
+        binary_url = bootstrap_args['binary'].gsub('$basearch', arch)
+        execute "Create #{repo_name}-#{arch}" do
+          command %W[
+            python3
+            #{pulp_data_directory}/initialize.py
+            #{repo_name}-#{arch}
+            #{repo_name}-#{arch}
+            --upstream-repository=#{binary_url}
+            --signing-service-name=#{gpg_key['fingerprint']}
+          ]
+          environment Hash[
+            "PULP_BASE_URL" => "http://127.0.0.1:24817",
+            "PULP_USERNAME" => "admin",
+            "PULP_PASSWORD" => pulp_admin_password,
+          ]
+        end
+
+        debug_url = bootstrap_args['debug'].gsub('$basearch', arch)
+        execute "Create #{repo_name}-#{arch}-debug" do
+          command %W[
+            python3
+            #{pulp_data_directory}/initialize.py
+            #{repo_name}-#{arch}-debug
+            #{repo_name}-#{arch}-debug
+            --upstream-repository=#{debug_url}
+            --signing-service-name=#{gpg_key['fingerprint']}
+          ]
+          environment Hash[
+            "PULP_BASE_URL" => "http://127.0.0.1:24817",
+            "PULP_USERNAME" => "admin",
+            "PULP_PASSWORD" => pulp_admin_password,
+          ]
+        end
+      end
+    end
+  end
+
   # * Create rpm repos
   node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
     versions.each do |version, architectures|

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -492,37 +492,22 @@ if node['ros_buildfarm']['repo']['enable_pulp_services']
     end
   end
 
-  # * Create bootstrap remotes
-  node['ros_buildfarm']['rpm_bootstrap_repos'].each do |dist, versions|
-    versions.each do |version, bootstrap_args|
-      repo_name = "ros-bootstrap-#{dist}-#{version}"
+  # * Create upstream remotes
+  node['ros_buildfarm']['rpm_upstream_repos'].each do |upstream_name, dists|
+    raise "Upstream repo '#{upstream_name}' contains unsupported character '-'" if upstream_name.include? '-'
 
-      source_url = bootstrap_args['source']
-      execute "Create #{repo_name}-SRPMS" do
-        command %W[
-          python3
-          #{pulp_data_directory}/initialize.py
-          #{repo_name}-SRPMS
-          #{repo_name}-SRPMS
-          --upstream-repository=#{source_url}
-          --signing-service-name=#{gpg_key['fingerprint']}
-        ]
-        environment Hash[
-          "PULP_BASE_URL" => "http://127.0.0.1:24817",
-          "PULP_USERNAME" => "admin",
-          "PULP_PASSWORD" => pulp_admin_password,
-        ]
-      end
+    dists.each do |dist, versions|
+      versions.each do |version, bootstrap_args|
+        repo_name = "ros-upstream-#{upstream_name}-#{dist}-#{version}"
 
-      bootstrap_args['architectures'].each do |arch|
-        binary_url = bootstrap_args['binary'].gsub('$basearch', arch)
-        execute "Create #{repo_name}-#{arch}" do
+        source_url = bootstrap_args['source']
+        execute "Create #{repo_name}-SRPMS" do
           command %W[
             python3
             #{pulp_data_directory}/initialize.py
-            #{repo_name}-#{arch}
-            #{repo_name}-#{arch}
-            --upstream-repository=#{binary_url}
+            #{repo_name}-SRPMS
+            #{repo_name}-SRPMS
+            --upstream-repository=#{source_url}
             --signing-service-name=#{gpg_key['fingerprint']}
           ]
           environment Hash[
@@ -532,21 +517,40 @@ if node['ros_buildfarm']['repo']['enable_pulp_services']
           ]
         end
 
-        debug_url = bootstrap_args['debug'].gsub('$basearch', arch)
-        execute "Create #{repo_name}-#{arch}-debug" do
-          command %W[
-            python3
-            #{pulp_data_directory}/initialize.py
-            #{repo_name}-#{arch}-debug
-            #{repo_name}-#{arch}-debug
-            --upstream-repository=#{debug_url}
-            --signing-service-name=#{gpg_key['fingerprint']}
-          ]
-          environment Hash[
-            "PULP_BASE_URL" => "http://127.0.0.1:24817",
-            "PULP_USERNAME" => "admin",
-            "PULP_PASSWORD" => pulp_admin_password,
-          ]
+        bootstrap_args['architectures'].each do |arch|
+          binary_url = bootstrap_args['binary'].gsub('$basearch', arch)
+          execute "Create #{repo_name}-#{arch}" do
+            command %W[
+              python3
+              #{pulp_data_directory}/initialize.py
+              #{repo_name}-#{arch}
+              #{repo_name}-#{arch}
+              --upstream-repository=#{binary_url}
+              --signing-service-name=#{gpg_key['fingerprint']}
+            ]
+            environment Hash[
+              "PULP_BASE_URL" => "http://127.0.0.1:24817",
+              "PULP_USERNAME" => "admin",
+              "PULP_PASSWORD" => pulp_admin_password,
+            ]
+          end
+
+          debug_url = bootstrap_args['debug'].gsub('$basearch', arch)
+          execute "Create #{repo_name}-#{arch}-debug" do
+            command %W[
+              python3
+              #{pulp_data_directory}/initialize.py
+              #{repo_name}-#{arch}-debug
+              #{repo_name}-#{arch}-debug
+              --upstream-repository=#{debug_url}
+              --signing-service-name=#{gpg_key['fingerprint']}
+            ]
+            environment Hash[
+              "PULP_BASE_URL" => "http://127.0.0.1:24817",
+              "PULP_USERNAME" => "admin",
+              "PULP_PASSWORD" => pulp_admin_password,
+            ]
+          end
         end
       end
     end


### PR DESCRIPTION
In `ros_buildfarm`, an `import-upstream` job for RPMs is implemented by searching for repos with a certain name (i.e. ros-buildfarm-foo-bar-baz) and triggering a 'sync' operation on those repos, then performing an operation similar to the sync operation that we do between building/testing/main, but between the candidate repo and each of building, testing, and main.

Creating the repo that has the 'sync' operation is similar to creating any other repo, except that it has a 'remote' associated with it.

This change implements the provisioning steps for the remote and the associated repo.