### PR TITLE
Drop GPG public key from RPM repository root

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -637,10 +637,7 @@ if node['ros_buildfarm']['repo']['enable_pulp_services']
         mode '0755'
       end
       file "#{repo_dir}/RPM-GPG-KEY-ros-#{repo}" do
-        content gpg_key['public_key']
-        owner agent_username
-        group agent_username
-        mode '0644'
+        action :delete
       end
 
       versions.each do |version, architectures|


### PR DESCRIPTION
Since we plan to point users to an HTTPS-hosted URL to download the public key, we shouldn't have it here. For other buildfarm deployments, the public key is still available in the repository metadata for download (as 'public.key').