### PR TITLE
Enable caching of some of the RPM repository metadata

### DIFF
--- a/templates/nginx/repo.conf.erb
+++ b/templates/nginx/repo.conf.erb
@@ -1,3 +1,5 @@
+proxy_cache_path /var/cache/nginx/rpm_md_cache levels=1:2 keys_zone=rpm_md_cache:10m max_size=1g inactive=1d use_temp_path=off;
+
 server {
 	listen 80 default_server;
 	server_name repo;
@@ -8,20 +10,35 @@ server {
 		index index.html;
 	}
 
+	set $no_cache 1;
+	if ($request_uri ~* "/repodata/.*-.*\.xml\.gz$") {
+		set $no_cache 0;
+	}
+
 	<%- @rpm_repos.each do |dist, versions| -%>
 		<%- versions.each do |version, architectures| -%>
 	location /<%= dist %>/building/<%= version %>/SRPMS/ {
-		# TODO more proxy_pass args
 		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-SRPMS/;
+		proxy_cache		rpm_md_cache;
+		proxy_cache_valid	200	1d;
+		proxy_no_cache		$no_cache;
+		proxy_cache_bypass	$no_cache;
+
 	}
 			<%- architectures.each do |arch| -%>
 	location /<%= dist %>/building/<%= version %>/<%= arch %>/debug/ {
-		# TODO more proxy_pass args
 		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-<%= arch %>-debug/;
+		proxy_cache		rpm_md_cache;
+		proxy_cache_valid	200	1d;
+		proxy_no_cache		$no_cache;
+		proxy_cache_bypass	$no_cache;
 	}
 	location /<%= dist %>/building/<%= version %>/<%= arch %>/ {
-		# TODO more proxy_pass args
 		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-<%= arch %>/;
+		proxy_cache		rpm_md_cache;
+		proxy_cache_valid	200	1d;
+		proxy_no_cache		$no_cache;
+		proxy_cache_bypass	$no_cache;
 	}
 
 			<%- end -%>

--- a/templates/nginx/repo.conf.erb
+++ b/templates/nginx/repo.conf.erb
@@ -23,7 +23,6 @@ server {
 		proxy_cache_valid	200	1d;
 		proxy_no_cache		$no_cache;
 		proxy_cache_bypass	$no_cache;
-
 	}
 			<%- architectures.each do |arch| -%>
 	location /<%= dist %>/building/<%= version %>/<%= arch %>/debug/ {

--- a/templates/nginx/repo.conf.erb
+++ b/templates/nginx/repo.conf.erb
@@ -1,4 +1,4 @@
-proxy_cache_path /var/cache/nginx/rpm_md_cache levels=1:2 keys_zone=rpm_md_cache:10m max_size=1g inactive=1d use_temp_path=off;
+proxy_cache_path /var/cache/nginx_rpm_md_cache levels=1:2 keys_zone=rpm_md_cache:10m max_size=1g inactive=1d use_temp_path=off;
 
 server {
 	listen 80 default_server;


### PR DESCRIPTION
The names of files which match the caching rule contain the content hashes, so the content at that URL should never change. These files disappear as the repository is updated, and this leads to a race between the loading of the repomd.xml and accessing the files listed within (and here in this config).

This isn't a complete solution for a variety of reasons, among them that it depends on a client accessing the content so that it can be cached to begin with. I'm hoping it will mitigate the problem, however.