### PR TITLE
Use systemd to manage GPG vault socket directory

### DIFF
--- a/files/gpg-vault-agent.service
+++ b/files/gpg-vault-agent.service
@@ -5,8 +5,10 @@ Documentation=man:gpg-agent(1)
 [Service]
 Type=forking
 User=gpg-vault
+RuntimeDirectory=gpg-vault
+RuntimeDirectoryMode=750
 ExecStart=/usr/bin/gpg-agent --daemon
-ExecStartPost=/bin/chmod ga+rw /var/run/gpg-vault/S.gpg-agent
+ExecStartPost=/bin/chmod ga+rw ${RUNTIME_DIRECTORY}/S.gpg-agent
 ExecReload=/usr/bin/gpgconf --reload gpg-agent
 
 [Install]


### PR DESCRIPTION
The directory currently being created by Chef doesn't persist across reboots. We can use systemd to manage the directory instead, which should mean that it is always created prior to starting, and always deleted after stopping.

https://www.freedesktop.org/software/systemd/man/systemd.exec.html#RuntimeDirectory=

Additionally, ensure that systemd reloads the gpg-vault-agent unit file when it is changed.