### PR TITLE
Add certificate update hook script for acme.sh.

### DIFF
--- a/files/cert-update-hook.sh
+++ b/files/cert-update-hook.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Run after acme.sh certificate renewal to restart or reload processes which must be notified of the updated cert.
+SERVICES="nginx"
+for service in $SERVICES; do
+	systemctl restart ${service}.service
+done

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -257,8 +257,12 @@ if node['ros_buildfarm']['letsencrypt_enabled']
       --fullchain-file #{cert_path}
       --key-file #{key_path}
       --reloadcmd /root/cert-update-hook.sh
+      --force
     )
-    not_if "test -d /root/.acme.sh/#{server_name}"
+    not_if {
+      File.directory?("/root/.acme.sh/#{server_name}") and not
+      File.read("/root/.acme.sh/#{server_name}/#{server_name}.conf").match(/Le_ReloadCmd=''/)
+    }
   end
 else
   template '/etc/nginx/sites-enabled/jenkins' do

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -262,7 +262,7 @@ if node['ros_buildfarm']['letsencrypt_enabled']
     not_if {
       # TODO the second guard clause can be removed after >= 0.6.0
       File.directory?("/root/.acme.sh/#{server_name}") and
-      File.read("/root/.acme.sh/#{server_name}/#{server_name}.conf").match(/Le_ReloadCmd='__ACME_BASE64__START_c3lzdGVtY3RsIHJlc3RhcnQgbmdpbng=__ACME_BASE64__END_'/)
+      File.read("/root/.acme.sh/#{server_name}/#{server_name}.conf").match(/Le_ReloadCmd='__ACME_BASE64__START_L3Jvb3QvY2VydC11cGRhdGUtaG9vay5zaA==__ACME_BASE64__END_'/)
     }
   end
 else

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -260,6 +260,7 @@ if node['ros_buildfarm']['letsencrypt_enabled']
       --force
     )
     not_if {
+      # TODO the second guard clause can be removed after >= 0.6.0
       File.directory?("/root/.acme.sh/#{server_name}") and not
       File.read("/root/.acme.sh/#{server_name}/#{server_name}.conf").match(/Le_ReloadCmd=''/)
     }

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -240,6 +240,13 @@ if node['ros_buildfarm']['letsencrypt_enabled']
     not_if 'test -x /root/.acme.sh/acme.sh'
   end
 
+  cookbook_file "/root/cert-update-hook.sh" do
+    source "cert-update-hook.sh"
+    owner "root"
+    group "root"
+    mode "0700"
+  end
+
   # Create Let's Encrypt signed cert if it has not already been done.
   execute 'acme-issue-cert' do
     environment 'HOME' => '/root'
@@ -249,6 +256,7 @@ if node['ros_buildfarm']['letsencrypt_enabled']
       --domain #{server_name}
       --fullchain-file #{cert_path}
       --key-file #{key_path}
+      --reloadcmd /root/cert-update-hook.sh
     )
     not_if "test -d /root/.acme.sh/#{server_name}"
   end

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -261,8 +261,8 @@ if node['ros_buildfarm']['letsencrypt_enabled']
     )
     not_if {
       # TODO the second guard clause can be removed after >= 0.6.0
-      File.directory?("/root/.acme.sh/#{server_name}") and not
-      File.read("/root/.acme.sh/#{server_name}/#{server_name}.conf").match(/Le_ReloadCmd=''/)
+      File.directory?("/root/.acme.sh/#{server_name}") and
+      File.read("/root/.acme.sh/#{server_name}/#{server_name}.conf").match(/Le_ReloadCmd='__ACME_BASE64__START_c3lzdGVtY3RsIHJlc3RhcnQgbmdpbng=__ACME_BASE64__END_'/)
     }
   end
 else


### PR DESCRIPTION
Nginx needs to be reloaded or restarted in order to re-read SSL
certificate files that acme.sh has updated.

In case other services ever need to be similarly restarted a separate
hook script is used to remove the need for updating the reloadcmd
directly.

This will resolve the issue we have periodically where acme.sh updates the certificate but nginx must be manually restarted before the new certificate will be served.