### PR TITLE
Notify `gpg --import` resources when key files change.

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -117,24 +117,26 @@ file '/home/gpg-vault/.gnupg/gpg_public_key.pub' do
   owner 'gpg-vault'
   group 'gpg-vault'
   mode '0644'
+  notifies :run, 'execute[gpg --import /home/gpg-vault/.gnupg/gpg_public_key.pub]', :immediately
 end
 execute 'gpg --import /home/gpg-vault/.gnupg/gpg_public_key.pub' do
   environment 'HOME' => '/home/gpg-vault'
   user 'gpg-vault'
   group 'gpg-vault'
-  not_if "gpg --list-keys #{gpg_key['fingerprint']}"
+  action :nothing # Only run if public key has changed.
 end
 file '/home/gpg-vault/.gnupg/gpg_private_key.sec' do
   content gpg_key['private_key']
   owner 'gpg-vault'
   group 'gpg-vault'
   mode '0600'
+  notifies :run, 'execute[gpg --import /home/gpg-vault/.gnupg/gpg_private_key.sec]', :immediately
 end
 execute 'gpg --import /home/gpg-vault/.gnupg/gpg_private_key.sec' do
   environment 'HOME' => '/home/gpg-vault'
   user 'gpg-vault'
   group 'gpg-vault'
-  not_if "gpg --list-secret-keys #{gpg_key['fingerprint']}"
+  action :nothing # Only run if secret key has changed.
 end
 group 'gpg-vault' do
   append true
@@ -192,12 +194,15 @@ file "/home/#{agent_username}/.ssh/gpg_private_key.sec" do
   group agent_username
   mode '0600'
   content gpg_key['private_key']
+  notifies :run, "execute[gpg --import /home/#{agent_username}/.ssh/gpg_private_key.sec]", :immediately
 end
 file '/var/repos/repos.key' do
   owner agent_username
   group agent_username
   mode '0644'
   content gpg_key['public_key']
+
+  notifies :run, 'execute[gpg --import /var/repos/repos.key]', :immediately
 end
 
 # Import public and private keys.
@@ -205,13 +210,13 @@ execute "gpg --import /var/repos/repos.key" do
   user agent_username
   group agent_username
   environment 'PATH' => '/bin:/usr/bin', 'HOME' => "/home/#{agent_username}"
-  not_if "gpg --list-keys #{gpg_key['fingerprint']}"
+  action :nothing # Only run if key is changed.
 end
 execute "gpg --import /home/#{agent_username}/.ssh/gpg_private_key.sec" do
   user agent_username
   group agent_username
   environment 'PATH' => '/bin:/usr/bin', 'HOME' => "/home/#{agent_username}"
-  not_if "gpg --list-secret-keys #{gpg_key['fingerprint']}"
+  action :nothing
 end
 
 # Import ROS bootstrap signing key for signature verification


### PR DESCRIPTION
This patch improves configuration behavior when key contents change.
When deploying changes to the public key, the keys on disk were updated
but the gpg keyring did not import the new keys since existing keys were
present.

Now, changes to the file resources will trigger runs of the import
execute resources which will provide the same behavior as before for
a freshly provisioned host but will correctly re-import keys when those
files change.