### PR TITLE
Update pulp base image to use Alma Linux.

### DIFF
--- a/files/pulp/Dockerfile
+++ b/files/pulp/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM almalinux:8
 
 RUN dnf install \
   epel-release \


### PR DESCRIPTION
This is sort of a straw man to get things started.

In discussion we talked about preferring Rocky Linux but I use Alma here
because there is no verifiably official Rocky Linux image.

The project at https://hub.docker.com/r/rockylinux/rockylinux is
official according to [this forum post from July][1] but it also has not
been updated for three months whereas the last Alma Linux build was 15
days ago.

[1]: https://forums.rockylinux.org/t/community-update-june-2021/3260/15