### PR TITLE
Update CI: stop using Chef 15, start using 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
           - 'repo'
           - 'jenkins'
         chef_version:
-          - '15'
           - '16'
+          - '17'
       fail-fast: false
     steps:
       - name: Check out code


### PR DESCRIPTION
Chef15 is problematic since it ships an outdated root certificate making some certs to fail, see https://github.com/ros-infrastructure/cookbook-ros-buildfarm/pull/100.

I'm setting 17 here to check if it is valid or we need to modify code.