### PR TITLE
Break out of the loop when timeout is exceeded waiting for pulp to be ready.

### DIFF
--- a/files/pulp/rpm_repo_init.py
+++ b/files/pulp/rpm_repo_init.py
@@ -119,6 +119,9 @@ def main(argv=sys.argv[1:]):
         time.sleep(1)
         status_timeout -= 1
 
+        if status_timeout <= 0:
+            break
+
     if pulp_is_ready:
         print('Connected - pulpcore is ready.')
     else:


### PR DESCRIPTION
The script will exit just after if pulp is not ready:

https://github.com/ros-infrastructure/cookbook-ros-buildfarm/pull/103/files#diff-f1618ef441961f957458058652fe7b71a5a373646e88d9666a40cb986797ad72R125-R129