### PR TITLE
Add an SSH publish endpoint for CI archives

### DIFF
--- a/attributes/ssh_publisher.rb
+++ b/attributes/ssh_publisher.rb
@@ -37,4 +37,5 @@ default['ros_buildfarm']['ssh_publisher']['repo_root_dir'] = '/var/repos/ubuntu/
 default['ros_buildfarm']['ssh_publisher']['docs_root_dir'] = '/var/repos/docs'
 default['ros_buildfarm']['ssh_publisher']['rosdistro_cache_root_dir'] = '/var/repos/rosdistro_cache'
 default['ros_buildfarm']['ssh_publisher']['status_page_root_dir'] = '/var/repos/status_page'
+default['ros_buildfarm']['ssh_publisher']['ci_archves_root_dir'] = '/var/repos/ci'
 

--- a/attributes/ssh_publisher.rb
+++ b/attributes/ssh_publisher.rb
@@ -37,5 +37,5 @@ default['ros_buildfarm']['ssh_publisher']['repo_root_dir'] = '/var/repos/ubuntu/
 default['ros_buildfarm']['ssh_publisher']['docs_root_dir'] = '/var/repos/docs'
 default['ros_buildfarm']['ssh_publisher']['rosdistro_cache_root_dir'] = '/var/repos/rosdistro_cache'
 default['ros_buildfarm']['ssh_publisher']['status_page_root_dir'] = '/var/repos/status_page'
-default['ros_buildfarm']['ssh_publisher']['ci_archves_root_dir'] = '/var/repos/ci'
+default['ros_buildfarm']['ssh_publisher']['ci_archives_root_dir'] = '/var/repos/ci_archives'
 

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -35,7 +35,7 @@ agent_username = node['ros_buildfarm']['agent']['agent_username']
   end
 end
 
-%w(docs rosdistro_cache status_page).each do |dir|
+%w(ci_archives docs rosdistro_cache status_page).each do |dir|
   directory "/var/repos/#{dir}" do
     owner agent_username
     group agent_username

--- a/templates/jenkins/jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin.xml.erb
+++ b/templates/jenkins/jenkins.plugins.publish_over_ssh.BapSshPublisherPlugin.xml.erb
@@ -98,6 +98,34 @@
       <proxyUser></proxyUser>
       <proxyPassword></proxyPassword>
     </jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
+    <jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
+      <name>ci_archives</name>
+      <hostname><%= node['ros_buildfarm']['ssh_publisher']['repo_hostname'] %></hostname>
+      <username><%= node['ros_buildfarm']['ssh_publisher']['repo_username'] %></username>
+      <secretPassword></secretPassword>
+      <remoteRootDir><%= node['ros_buildfarm']['ssh_publisher']['ci_archives_root_dir'] %></remoteRootDir>
+      <port><%= node['ros_buildfarm']['ssh_publisher']['repo_port'] %></port>
+      <commonConfig class="jenkins.plugins.publish_over_ssh.BapSshCommonConfiguration">
+        <secretPassword></secretPassword>
+        <key><%= @ssh_key %></key>
+        <keyPath></keyPath>
+        <disableAllExec>true</disableAllExec>
+      </commonConfig>
+      <timeout><%= node['ros_buildfarm']['ssh_publisher']['repo_timeout'] %></timeout>
+      <overrideKey>false</overrideKey>
+      <disableExec>false</disableExec>
+      <keyInfo>
+        <secretPassphrase></secretPassphrase>
+        <key></key>
+        <keyPath></keyPath>
+      </keyInfo>
+      <jumpHost></jumpHost>
+      <proxyType></proxyType>
+      <proxyHost></proxyHost>
+      <proxyPort>0</proxyPort>
+      <proxyUser></proxyUser>
+      <proxyPassword></proxyPassword>
+    </jenkins.plugins.publish__over__ssh.BapSshHostConfiguration>
   </hostConfigurations>
   <commonConfig reference="../hostConfigurations/jenkins.plugins.publish__over__ssh.BapSshHostConfiguration/commonConfig"/>
   <defaults class="jenkins.plugins.publish_over_ssh.options.SshPluginDefaults"/>


### PR DESCRIPTION
This change adds an SSH publisher endpoint for storing CI archives on repo.ros2.org. As it stands, we have no plans to sync these archives off from the repo host, but that may change in the future.

For our immediate needs, getting the archive out of Jenkins should be good enough. We can re-evaluate later if bandwidth becomes a problem.