### PR TITLE
Update project to cinc/chef 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,7 @@ jobs:
           - 'repo'
           - 'jenkins'
         chef_version:
-          - '15'
-          - '16'
+          - '17'
       fail-fast: false
     steps:
       - name: Check out code

--- a/Berksfile
+++ b/Berksfile
@@ -5,4 +5,4 @@ source 'https://supermarket.chef.io'
 metadata
 
 # TODO: Update to a released cookbook version once the auth retry is upstream.
-cookbook "jenkins", "8.0.4"
+cookbook "jenkins", "9.5.0"

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,7 +4,7 @@ driver:
 provisioner:
   name: chef_solo
   product_name: chef
-  product_version: 15
+  product_version: 17
   solo_rb:
     environment: test
 


### PR DESCRIPTION
Chef 15 is no longer supported and issues with OpenSSL certificates are blocking deployment using it. 
I was locally testing the move first to Chef 16 and when that went fine I bumped to 17 to see the damage.
There was only one deprecation warning which was resolved with an update to the latest version of the Jenkins cookbook.
That update also simplifies the dependency situation (resolving the deprecation warning) and so is generally positive.

The Jenkins role is still unable to converge due to a plugin being delisted which is being handled in a separate PR.