### PR TITLE
Update seccomp profile to moby/moby 20.10.12.

### DIFF
--- a/files/docker-seccomp-default-with-personality.json
+++ b/files/docker-seccomp-default-with-personality.json
@@ -74,6 +74,7 @@
 				"clock_nanosleep",
 				"clock_nanosleep_time64",
 				"close",
+				"close_range",
 				"connect",
 				"copy_file_range",
 				"creat",
@@ -85,6 +86,7 @@
 				"epoll_ctl",
 				"epoll_ctl_old",
 				"epoll_pwait",
+				"epoll_pwait2",
 				"epoll_wait",
 				"epoll_wait_old",
 				"eventfd",
@@ -590,10 +592,17 @@
 			"names": [
 				"bpf",
 				"clone",
+				"clone3",
 				"fanotify_init",
+				"fsconfig",
+				"fsmount",
+				"fsopen",
+				"fspick",
 				"lookup_dcookie",
 				"mount",
+				"move_mount",
 				"name_to_handle_at",
+				"open_tree",
 				"perf_event_open",
 				"quotactl",
 				"setdomainname",
@@ -665,6 +674,21 @@
 		},
 		{
 			"names": [
+				"clone3"
+			],
+			"action": "SCMP_ACT_ERRNO",
+			"errnoRet": 38,
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
 				"reboot"
 			],
 			"action": "SCMP_ACT_ALLOW",
@@ -725,6 +749,7 @@
 			"names": [
 				"kcmp",
 				"pidfd_getfd",
+				"process_madvise",
 				"process_vm_readv",
 				"process_vm_writev",
 				"ptrace"


### PR DESCRIPTION
This pulls in the default seccomp profile from moby/moby 20.10.12 which includes, among other changes, support for the clone3 system call which is being blocked in our current Ubuntu Jammy sourcedeb containers.

The personality system call for sbcl in ROS 1 is maintained.