### PR TITLE
Add letsencrypt support for the repository host.

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -21,6 +21,10 @@ default['ros_buildfarm']['apt_repos']['suites'] = %w[xenial bionic focal stretch
 # ```
 default['ros_buildfarm']['repo']['rsyncd_endpoints'] = Hash[]
 
+# The repository host server name is currently only used to provide
+# a server name when using letsencrypt for https and is environment-specific.
+default['ros_buildfarm']['repo']['server_name'] = nil
+
 # The ros_buildfarm jobs are configured to try and pull the latest container
 # image from the Docker registry at the start of each job.  To prevent that
 # from consuming excess bandwidth and rate limited Docker API requests the repo

--- a/recipes/acmesh.rb
+++ b/recipes/acmesh.rb
@@ -1,0 +1,21 @@
+# Install acme.sh for certificate signing and renewal.  git is required for acme.sh's setup
+package 'git'
+execute 'git clone https://github.com/acmesh-official/acme.sh' do
+  cwd '/root'
+  not_if 'test -d /root/acme.sh'
+end
+execute 'acmesh-install' do
+  environment 'HOME' => '/root'
+  cwd '/root/acme.sh'
+  cmd = './acme.sh --install --home /root/.acme.sh'
+  cmd << " --accountemail #{node['ros_buildfarm']['letsencrypt_email']}" if node['ros_buildfarm']['letsencrypt_email']
+  command cmd
+  not_if 'test -x /root/.acme.sh/acme.sh'
+end
+
+cookbook_file "/root/cert-update-hook.sh" do
+  source "cert-update-hook.sh"
+  owner "root"
+  group "root"
+  mode "0700"
+end

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -234,27 +234,7 @@ if node['ros_buildfarm']['letsencrypt_enabled']
     notifies :restart, 'service[nginx]', :immediately
   end
 
-  # Install acme.sh for certificate signing and renewal.  git is required for acme.sh's setup
-  package 'git'
-  execute 'git clone https://github.com/acmesh-official/acme.sh' do
-    cwd '/root'
-    not_if 'test -d /root/acme.sh'
-  end
-  execute 'acmesh-install' do
-    environment 'HOME' => '/root'
-    cwd '/root/acme.sh'
-    cmd = './acme.sh --install --home /root/.acme.sh'
-    cmd << " --accountemail #{node['ros_buildfarm']['letsencrypt_email']}" if node['ros_buildfarm']['letsencrypt_email']
-    command cmd
-    not_if 'test -x /root/.acme.sh/acme.sh'
-  end
-
-  cookbook_file "/root/cert-update-hook.sh" do
-    source "cert-update-hook.sh"
-    owner "root"
-    group "root"
-    mode "0700"
-  end
+  include_recipe "ros_buildfarm::acmesh"
 
   # Create Let's Encrypt signed cert if it has not already been done.
   execute 'acme-issue-cert' do

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -246,6 +246,7 @@ if node['ros_buildfarm']['letsencrypt_enabled']
       --fullchain-file #{cert_path}
       --key-file #{key_path}
       --reloadcmd /root/cert-update-hook.sh
+      --server letsencrypt
       --force
     )
     not_if {

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -771,6 +771,7 @@ if node['ros_buildfarm']['letsencrypt_enabled']
       --fullchain-file #{cert_path}
       --key-file #{key_path}
       --reloadcmd /root/cert-update-hook.sh
+      --server letsencrypt
       --force
     )
     not_if { ::File.directory? "/root/.acme.sh/#{server_name}" }

--- a/templates/nginx/repo.conf.erb
+++ b/templates/nginx/repo.conf.erb
@@ -1,7 +1,19 @@
 server {
 	listen 80 default_server;
-	server_name repo;
+	<% if @letsencrypt_enabled %>
+	listen 443 ssl default_server;
+	ssl_certificate <%= @cert_path %>;
+	ssl_certificate_key <%= @key_path %>;
+	<% end %>
+	server_name <% if @server_name %><%= @server_name %><% else %>repo<% end %>;
 	root /var/repos;
+
+	# Allow ACME challenge to access the webroot directly.
+	location '/.well-known/acme-challenge' {
+		default_type "text/plain";
+		root /var/www/html;
+		allow all;
+	}
 
 	location / {
 		autoindex on;


### PR DESCRIPTION
Like the Jenkins host, the repo host may also be publicly exposed. Apt repositories don't require https for repository integrity since that's achieved through GPG key signing repository metadata.

However other resources on the repository host may benefit from having a secure transport mechanism. Including the secure distribution of the public key information used for the apt security process or other artifacts hosted on the repository server.