### PR TITLE
Build the pulp docker image in its own directory.

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -338,6 +338,9 @@ end
 directory "#{pulp_data_directory}/media" do
   owner 'pulp'
 end
+directory "#{pulp_data_directory}/docker_image" do
+  owner 'pulp'
+end
 
 cookbook_file "#{pulp_data_directory}/initialize.py" do
   owner 'pulp'
@@ -375,13 +378,13 @@ remote_file "/usr/local/bin/systemd-docker" do
   source 'https://github.com/nuclearsandwich/systemd-docker/releases/download/subdavis-1.0.0/systemd-docker-linux-amd64'
   mode '0755'
 end
-cookbook_file "#{pulp_data_directory}/Dockerfile" do
+cookbook_file "#{pulp_data_directory}/docker_image/Dockerfile" do
   source 'pulp/Dockerfile'
 end
 
 if node['ros_buildfarm']['repo']['enable_pulp_services']
   execute 'docker build -t pulp_image .' do
-    cwd pulp_data_directory
+    cwd "#{pulp_data_directory}/docker_image"
   end
 
   execute 'pulp_django_migration' do


### PR DESCRIPTION
The first thing that docker-build does is "send the build context to the
Docker daemon. This context includes the entire current directory of the
build. When rebuilding an image on an active host, this directory
includes the `media` subdirectory full of repository content.
On repo.ros2.org this directory is over 100GB in size.
As a result the docker build time is untenable. I have not even seen the
docker build start as I've aborted both builds after over 15 minutes of
"sending data".

The pulp_image dockerfile contains no ADD or COPY commands and so does
not appear to require any of the contents of the pulp data directory
beyond its own Dockerfile.