### PR TITLE
Add createrepo-agent to repo host alongside Pulp

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -321,6 +321,13 @@ node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
         not_if { ::File.exist?("#{srpms_dir}/repodata/repomd.xml") }
       end
 
+      execute "gpg --armor --detach --sign --yes --default-key=#{gpg_key['fingerprint']} #{srpms_dir}/repodata/repomd.xml" do
+        user agent_username
+        group agent_username
+        environment 'HOME' => "/home/#{agent_username}"
+        not_if { ::File.exist?("#{srpms_dir}/repodata/repomd.xml.asc") }
+      end
+
       architectures.each do |arch|
         arch_dir = "#{version_dir}/#{arch}"
         debug_dir = "#{arch_dir}/debug"
@@ -338,10 +345,24 @@ node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
           not_if { ::File.exist?("#{arch_dir}/repodata/repomd.xml") }
         end
 
+        execute "gpg --armor --detach --sign --yes --default-key=#{gpg_key['fingerprint']} #{arch_dir}/repodata/repomd.xml" do
+          user agent_username
+          group agent_username
+          environment 'HOME' => "/home/#{agent_username}"
+          not_if { ::File.exist?("#{arch_dir}/repodata/repomd.xml.asc") }
+        end
+
         execute "createrepo_c --no-database #{debug_dir}" do
           user agent_username
           group agent_username
           not_if { ::File.exist?("#{debug_dir}/repodata/repomd.xml") }
+        end
+
+        execute "gpg --armor --detach --sign --yes --default-key=#{gpg_key['fingerprint']} #{debug_dir}/repodata/repomd.xml" do
+          user agent_username
+          group agent_username
+          environment 'HOME' => "/home/#{agent_username}"
+          not_if { ::File.exist?("#{debug_dir}/repodata/repomd.xml.asc") }
         end
       end
     end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -284,6 +284,70 @@ end
   end
 end
 
+# RPM repository setup
+apt_repository 'createrepo-agent-ppa' do
+  uri 'ppa:osrf/createrepo-agent'
+end
+
+package 'createrepo-agent'
+
+package 'createrepo-c'
+
+package 'rpm'
+
+node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
+  dist_dir = "/var/repos/#{dist}_cra"
+
+  %w(building testing main).each do |repo|
+    repo_dir = "#{dist_dir}/#{repo}"
+    file "#{repo_dir}/RPM-GPG-KEY-ros-#{repo}" do
+      action :delete
+    end
+
+    versions.each do |version, architectures|
+      version_dir = "#{repo_dir}/#{version}"
+      srpms_dir = "#{version_dir}/SRPMS"
+      [dist_dir, repo_dir, version_dir, srpms_dir].each do |dir|
+        directory dir do
+          owner agent_username
+          group agent_username
+          mode '0755'
+        end
+      end
+
+      execute "createrepo_c --no-database #{srpms_dir}" do
+        user agent_username
+        group agent_username
+        not_if { ::File.exist?("#{srpms_dir}/repodata/repomd.xml") }
+      end
+
+      architectures.each do |arch|
+        arch_dir = "#{version_dir}/#{arch}"
+        debug_dir = "#{arch_dir}/debug"
+        [arch_dir, debug_dir].each do |dir|
+          directory dir do
+            owner agent_username
+            group agent_username
+            mode '0755'
+          end
+        end
+
+        execute "createrepo_c --no-database #{arch_dir} --excludes=debug/*" do
+          user agent_username
+          group agent_username
+          not_if { ::File.exist?("#{arch_dir}/repodata/repomd.xml") }
+        end
+
+        execute "createrepo_c --no-database #{debug_dir}" do
+          user agent_username
+          group agent_username
+          not_if { ::File.exist?("#{debug_dir}/repodata/repomd.xml") }
+        end
+      end
+    end
+  end
+end
+
 # Pulp setup
 pulp_data_directory = '/var/repos/.pulp'
 user 'pulp' do


### PR DESCRIPTION
This change adds the necessary configuration for using createrepo-agent on the repo host for RPM repository management, and creates a separate repository tree alongside the Pulp one for comparison.

When we're ready to switch, just drop the `_cra` suffix from the repository directory name and remove all of the pulp stuff.