### PR TITLE
Switch from Pulp to createrepo-agent for RPMs

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -42,6 +42,7 @@ default['ros_buildfarm']['repo']['container_registry_cache_enabled'] = true
 default['ros_buildfarm']['repo']['pulp_worker_count'] = 2
 default['ros_buildfarm']['repo']['enable_pulp_services'] = true
 default['ros_buildfarm']['rpm_repos']['rhel']['8'] = %w[x86_64]
+default['ros_buildfarm']['rpm_repos']['bootstrap_url'] = 'http://repos.ros.org/repos/$distname/ros_bootstrap/$releasever/$basearch/'
 default['ros_buildfarm']['rpm_upstream_repos']['bootstrap']['rhel']['8'] = Hash[
   architectures: %w[x86_64],
   binary: 'http://repos.ros.org/repos/rhel/ros_bootstrap/8/$basearch/',

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -42,7 +42,7 @@ default['ros_buildfarm']['repo']['container_registry_cache_enabled'] = true
 default['ros_buildfarm']['repo']['pulp_worker_count'] = 2
 default['ros_buildfarm']['repo']['enable_pulp_services'] = true
 default['ros_buildfarm']['rpm_repos']['rhel']['8'] = %w[x86_64]
-default['ros_buildfarm']['rpm_repos']['bootstrap_url'] = 'http://repos.ros.org/repos/$distname/ros_bootstrap/$releasever/$basearch/'
+default['ros_buildfarm']['rpm_bootstrap_url'] = 'http://repos.ros.org/repos/$distname/ros_bootstrap/$releasever/$basearch/'
 default['ros_buildfarm']['rpm_upstream_repos']['bootstrap']['rhel']['8'] = Hash[
   architectures: %w[x86_64],
   binary: 'http://repos.ros.org/repos/rhel/ros_bootstrap/8/$basearch/',

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -42,7 +42,7 @@ default['ros_buildfarm']['repo']['container_registry_cache_enabled'] = true
 default['ros_buildfarm']['repo']['pulp_worker_count'] = 2
 default['ros_buildfarm']['repo']['enable_pulp_services'] = true
 default['ros_buildfarm']['rpm_repos']['rhel']['8'] = %w[x86_64]
-default['ros_buildfarm']['rpm_bootstrap_url'] = 'http://repos.ros.org/repos/$distname/ros_bootstrap/$releasever/$basearch/'
+default['ros_buildfarm']['rpm_bootstrap_urls'] = ['http://repos.ros.org/repos/$distname/ros_bootstrap/$releasever/$basearch/']
 default['ros_buildfarm']['rpm_upstream_repos']['bootstrap']['rhel']['8'] = Hash[
   architectures: %w[x86_64],
   binary: 'http://repos.ros.org/repos/rhel/ros_bootstrap/8/$basearch/',

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -713,7 +713,7 @@ if node['ros_buildfarm']['repo']['enable_pulp_services']
       mode '0755'
     end
 
-    %w(building testing main).each do |repo|
+    %w(building).each do |repo|
       repo_dir = "#{dist_dir}/#{repo}"
       directory repo_dir do
         owner agent_username

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -369,6 +369,15 @@ node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
   end
 end
 
+if node['ros_buildfarm']['rpm_repos']['bootstrap_url']
+  file "/home/#{agent_username}/ros_bootstrap_rpm_urls.txt" do
+    owner agent_username
+    group agent_username
+    mode '0644'
+    content node['ros_buildfarm']['rpm_repos']['bootstrap_url']
+  end
+end
+
 # Pulp setup
 pulp_data_directory = '/var/repos/.pulp'
 user 'pulp' do

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -289,22 +289,15 @@ apt_repository 'createrepo-agent-ppa' do
   uri 'ppa:osrf/createrepo-agent'
 end
 
-package 'createrepo-agent'
-
-package 'createrepo-c'
-
-package 'rpm'
-
-package 'socat'
+%w[createrepo-agent createrepo-c rpm socat].each do |pkg|
+  package pkg
+end
 
 node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
   dist_dir = "/var/repos/#{dist}"
 
   %w(building testing main).each do |repo|
     repo_dir = "#{dist_dir}/#{repo}"
-    file "#{repo_dir}/RPM-GPG-KEY-ros-#{repo}" do
-      action :delete
-    end
 
     versions.each do |version, architectures|
       version_dir = "#{repo_dir}/#{version}"
@@ -371,12 +364,12 @@ node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
   end
 end
 
-if not node['ros_buildfarm']['rpm_bootstrap_url'].empty?
+if not node['ros_buildfarm']['rpm_bootstrap_urls'].empty?
   file "/home/#{agent_username}/ros_bootstrap_rpm_urls.txt" do
     owner agent_username
     group agent_username
     mode '0644'
-    content node['ros_buildfarm']['rpm_bootstrap_url']
+    content node['ros_buildfarm']['rpm_bootstrap_urls'].join("\n")
   end
 end
 

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -321,6 +321,13 @@ node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
         not_if { ::File.exist?("#{srpms_dir}/repodata/repomd.xml") }
       end
 
+      execute "gpg --armor --detach --sign --yes --default-key=#{gpg_key['fingerprint']} #{srpms_dir}/repodata/repomd.xml" do
+        user agent_username
+        group agent_username
+        environment 'HOME' => "/home/#{agent_username}"
+        not_if { ::File.exist?("#{srpms_dir}/repodata/repomd.xml.asc") }
+      end
+
       architectures.each do |arch|
         arch_dir = "#{version_dir}/#{arch}"
         debug_dir = "#{arch_dir}/debug"
@@ -338,10 +345,24 @@ node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
           not_if { ::File.exist?("#{arch_dir}/repodata/repomd.xml") }
         end
 
+        execute "gpg --armor --detach --sign --yes --default-key=#{gpg_key['fingerprint']} #{arch_dir}/repodata/repomd.xml" do
+          user agent_username
+          group agent_username
+          environment 'HOME' => "/home/#{agent_username}"
+          not_if { ::File.exist?("#{arch_dir}/repodata/repomd.xml.asc") }
+        end
+
         execute "createrepo_c --no-database #{debug_dir}" do
           user agent_username
           group agent_username
           not_if { ::File.exist?("#{debug_dir}/repodata/repomd.xml") }
+        end
+
+        execute "gpg --armor --detach --sign --yes --default-key=#{gpg_key['fingerprint']} #{debug_dir}/repodata/repomd.xml" do
+          user agent_username
+          group agent_username
+          environment 'HOME' => "/home/#{agent_username}"
+          not_if { ::File.exist?("#{debug_dir}/repodata/repomd.xml.asc") }
         end
       end
     end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -284,6 +284,70 @@ end
   end
 end
 
+# RPM repository setup
+apt_repository 'createrepo-agent-ppa' do
+  uri 'ppa:osrf/createrepo-agent'
+end
+
+package 'createrepo-agent'
+
+package 'createrepo-c'
+
+package 'rpm'
+
+node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
+  dist_dir = "/var/repos/#{dist}_cra"
+
+  %w(building testing main).each do |repo|
+    repo_dir = "#{dist_dir}/#{repo}"
+    file "#{repo_dir}/RPM-GPG-KEY-ros-#{repo}" do
+      action :delete
+    end
+
+    versions.each do |version, architectures|
+      version_dir = "#{repo_dir}/#{version}"
+      srpms_dir = "#{version_dir}/SRPMS"
+      [dist_dir, repo_dir, version_dir, srpms_dir].each do |dir|
+        directory dir do
+          owner agent_username
+          group agent_username
+          mode '0755'
+        end
+      end
+
+      execute "createrepo_c --no-database #{srpms_dir}" do
+        user agent_username
+        group agent_username
+        not_if { ::File.exist?("#{srpms_dir}/repodata/repomd.xml") }
+      end
+
+      architectures.each do |arch|
+        arch_dir = "#{version_dir}/#{arch}"
+        debug_dir = "#{arch_dir}/debug"
+        [arch_dir, debug_dir].each do |dir|
+          directory dir do
+            owner agent_username
+            group agent_username
+            mode '0755'
+          end
+        end
+
+        execute "createrepo_c --no-database #{arch_dir} --excludes=debug/*" do
+          user agent_username
+          group agent_username
+          not_if { ::File.exist?("#{arch_dir}/repodata/repomd.xml") }
+        end
+
+        execute "createrepo_c --no-database #{debug_dir}" do
+          user agent_username
+          group agent_username
+          not_if { ::File.exist?("#{debug_dir}/repodata/repomd.xml") }
+        end
+      end
+    end
+  end
+end
+
 # Pulp setup
 pulp_data_directory = '/var/repos/.pulp'
 user 'pulp' do

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -371,12 +371,12 @@ node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
   end
 end
 
-if node['ros_buildfarm']['rpm_repos']['bootstrap_url']
+if not node['ros_buildfarm']['rpm_bootstrap_url'].empty?
   file "/home/#{agent_username}/ros_bootstrap_rpm_urls.txt" do
     owner agent_username
     group agent_username
     mode '0644'
-    content node['ros_buildfarm']['rpm_repos']['bootstrap_url']
+    content node['ros_buildfarm']['rpm_bootstrap_url']
   end
 end
 

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -713,7 +713,7 @@ if node['ros_buildfarm']['repo']['enable_pulp_services']
       mode '0755'
     end
 
-    %w(building).each do |repo|
+    %w(building testing main).each do |repo|
       repo_dir = "#{dist_dir}/#{repo}"
       directory repo_dir do
         owner agent_username

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -295,6 +295,8 @@ package 'createrepo-c'
 
 package 'rpm'
 
+package 'socat'
+
 node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
   dist_dir = "/var/repos/#{dist}"
 

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -296,7 +296,7 @@ package 'createrepo-c'
 package 'rpm'
 
 node['ros_buildfarm']['rpm_repos'].each do |dist, versions|
-  dist_dir = "/var/repos/#{dist}_cra"
+  dist_dir = "/var/repos/#{dist}"
 
   %w(building testing main).each do |repo|
     repo_dir = "#{dist_dir}/#{repo}"
@@ -706,7 +706,7 @@ if node['ros_buildfarm']['repo']['enable_pulp_services']
       end
     end
 
-    dist_dir = "/var/repos/#{dist}"
+    dist_dir = "/var/repos/#{dist}_pulp"
     directory dist_dir do
       owner agent_username
       group agent_username

--- a/templates/nginx/repo.conf.erb
+++ b/templates/nginx/repo.conf.erb
@@ -22,16 +22,16 @@ server {
 
 	<%- @rpm_repos.each do |dist, versions| -%>
 		<%- versions.each do |version, architectures| -%>
-	location /<%= dist %>/building/<%= version %>/SRPMS/ {
+	location /<%= dist %>_pulp/building/<%= version %>/SRPMS/ {
 		# TODO more proxy_pass args
 		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-SRPMS/;
 	}
 			<%- architectures.each do |arch| -%>
-	location /<%= dist %>/building/<%= version %>/<%= arch %>/debug/ {
+	location /<%= dist %>_pulp/building/<%= version %>/<%= arch %>/debug/ {
 		# TODO more proxy_pass args
 		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-<%= arch %>-debug/;
 	}
-	location /<%= dist %>/building/<%= version %>/<%= arch %>/ {
+	location /<%= dist %>_pulp/building/<%= version %>/<%= arch %>/ {
 		# TODO more proxy_pass args
 		proxy_pass	http://127.0.0.1:24816/pulp/content/ros-building-<%= dist %>-<%= version %>-<%= arch %>/;
 	}


### PR DESCRIPTION
This change switches the RPM repository management solution from Pulp to `createrepo-agent`. It leaves Pulp configured and running, but moves the endpoint from `http://example.com/{os_name}/building/{os_verison}/{os_arch}` to `http://example.com/{os_name}_pulp/building/{os_verison}/{os_arch}`. Existing `testing` and `main` repositories are left untouched, and will be managed by `createrepo-agent` automatically on-demand.

There is a one-time manual migration that must be performed to copy the existing contents of the `building` repository from Pulp to `createrepo-agent`. After deployment is complete, run the following command on the repo host **as the `jenkins-agent` user**:
```
$ createrepo-agent --sync=http://127.0.0.1/rhel_pulp/building/8/ --arch=SRPMS --arch=x86_64 /var/repos/rhel/building/8/
```