### PR TITLE
Unblock Jenkins upgrades by switching to Java 11.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,4 +5,4 @@ source 'https://supermarket.chef.io'
 metadata
 
 # TODO: Update to a released cookbook version once the auth retry is upstream.
-cookbook "jenkins", "9.5.0"
+cookbook "jenkins", "9.5.2"

--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,4 @@ source 'https://supermarket.chef.io'
 # Checks metadata.rb for dependencies
 metadata
 
-# TODO: Update to a released cookbook version once the auth retry is upstream.
 cookbook "jenkins", "9.5.2"

--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -19,3 +19,5 @@ default['ros_buildfarm']['letsencrypt_enabled'] = false
 
 # When set to true a postfix SMTP server will be configured for use by Jenkins via sendmail.
 default['ros_buildfarm']['smtp'] = false
+
+default['jenkins']['master']['version'] = '2.346.1'

--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -20,4 +20,7 @@ default['ros_buildfarm']['letsencrypt_enabled'] = false
 # When set to true a postfix SMTP server will be configured for use by Jenkins via sendmail.
 default['ros_buildfarm']['smtp'] = false
 
-default['jenkins']['master']['version'] = '2.346.1'
+# Last version supporting Java 8
+#default['jenkins']['master']['version'] = '2.346.1'
+# Last version supporting sysvinit scripts
+default['jenkins']['master']['version'] = '2.319.3'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,8 @@ driver:
   vagrant
 provisioner:
   name: chef_solo
-  product_name: chef
+  product_name: cinc
+  download_url: https://omnitruck.cinc.sh/install.sh
   product_version: 17
   solo_rb:
     environment: test

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -30,7 +30,7 @@ end
 # Without this the recipe fails on AWS instances with empty apt caches.
 apt_update
 
-package 'openjdk-8-jdk-headless'
+package 'openjdk-11-jdk-headless'
 include_recipe 'jenkins::master'
 
 # Set up authentication

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -30,7 +30,7 @@ end
 # Without this the recipe fails on AWS instances with empty apt caches.
 apt_update
 
-package 'openjdk-11-jdk-headless'
+package 'openjdk-8-jdk-headless'
 include_recipe 'jenkins::master'
 
 # Set up authentication

--- a/test/integration/data_bags/ros_buildfarm_publish_over_ssh_key/test.json
+++ b/test/integration/data_bags/ros_buildfarm_publish_over_ssh_key/test.json
@@ -1,4 +1,5 @@
 {
   "id": "test",
-  "ssh_key": "SSH KEY TEXT"
+  "private_key": "SSH KEY TEXT",
+  "public_key": "PUBLIC KEY TEXT"
 }


### PR DESCRIPTION
This is based on work done together with @orensbruli this morning.

We're still not building but this fixes some of the infra level changes.

Before this can merge we'll need to assess to to perform this migration in production.