### PR TITLE
Pin the last Jenkins package which uses sysvinit scripts.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,5 +4,4 @@ source 'https://supermarket.chef.io'
 # Checks metadata.rb for dependencies
 metadata
 
-# TODO: Update to a released cookbook version once the auth retry is upstream.
-cookbook "jenkins", "9.5.0"
+cookbook "jenkins", "9.5.19"

--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -19,3 +19,8 @@ default['ros_buildfarm']['letsencrypt_enabled'] = false
 
 # When set to true a postfix SMTP server will be configured for use by Jenkins via sendmail.
 default['ros_buildfarm']['smtp'] = false
+
+# Last version supporting Java 8
+#default['jenkins']['master']['version'] = '2.346.1'
+# Last version supporting sysvinit scripts
+default['jenkins']['master']['version'] = '2.319.3'

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -31,6 +31,53 @@ end
 apt_update
 
 package 'openjdk-8-jdk-headless'
+# Jenkins downgrade protection
+#
+# The Jenkins package has transitioned to using systemd units instead of
+# sysvinit style init scripts. In order to maintain this cookbook the last
+# version of Jenkins which is packaged with a sysvinit script is pinned.
+# However Jenkins cannot be safely downgraded and some configurations of
+# Jenkins will continue to function once initially configured even after the
+# systemd switch.
+# To protect users from unintentional downgrades we're going to do something really ugly here.
+package 'jenkins' do
+  action :lock
+  only_if { -> do
+    jenkins_info = `dpkg -s jenkins`
+    if $?.exitstatus != 0
+       return false
+    end
+
+    version_line = jenkins_info.lines.select{|line| line =~ /^Version: /}.first
+    if version_line.nil?
+      return false
+    end
+
+    # Transform "Version: 2.319.1\n" to ["2", "319", "1"]
+    version_components = version_line.chomp.split(": ")[1].split(".")
+    # The first systemd versions are 2.335 (weekly) and 2.332.1 (LTS)
+    if version_components[0].to_i > 2 or version_components[1].to_i >= 332
+      node.run_state[:jenkins_package_version_lock] = version_components.join('.')
+      Chef::Log.warn("Chef detected this Jenkins version: #{node.run_state[:jenkins_package_version_lock]}")
+      return true
+    end
+    # Jenkins is installed but is older than the maximum and can be upgraded.
+    return false
+  end.call }
+end
+
+ruby_block 'prevent jenkins downgrade' do
+  block do
+    if node.run_state[:jenkins_package_version_lock]
+      if node['jenkins']['master']['version'] != node.run_state[:jenkins_package_version_lock]
+        Chef::Log.fatal("Before this cookbook continues, please set the node['jenkins']['master']['version'] attribute to #{node.run_state[:jenkins_package_version_lock]} or this cookbook will attempt to downgrade your Jenkins version.")
+        Chef::Log.fatal("See https://github.com/ros-infrastructure/cookbook-ros-buildfarm/issues/121 for more information")
+        raise
+      end
+    end
+  end
+end
+
 include_recipe 'jenkins::master'
 
 # Set up authentication

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -50,7 +50,8 @@ package 'jenkins' do
 
     version_line = jenkins_info.lines.select{|line| line =~ /^Version: /}.first
     if version_line.nil?
-      return false
+      Chef::Log.fatal("Could not determine Jenkins version from dpkg but it does seem installed.")
+      raise
     end
 
     # Transform "Version: 2.319.1\n" to ["2", "319", "1"]


### PR DESCRIPTION
Earlier this year the packaged versions of Jenkins migrated to systemd units from sysvinit scripts. The current versions of the Jenkins chef cookbook and this cookbook both expect Jenkins to run using sysvinit and make configuration changes using the associated configuration files which are not used by the systemd service.

As a result, newer versions of the Jenkins will not initialize correctly with this cookbook.

Until the upstream Jenkins cookbook is updated to use systemd or we stop using the upstream cookbook entirely, we can't move forward from this Jenkins version.

It is possible for an already-configured farm to continue working after an upgrade and Jenkins cannot be safely downgraded so this version pin is a breaking change and additional work to protect from an unintended downgrade may be warranted.