### PR TITLE
Add RHEL 9 repositories

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -42,10 +42,17 @@ default['ros_buildfarm']['repo']['container_registry_cache_enabled'] = true
 default['ros_buildfarm']['repo']['pulp_worker_count'] = 2
 default['ros_buildfarm']['repo']['enable_pulp_services'] = true
 default['ros_buildfarm']['rpm_repos']['rhel']['8'] = %w[x86_64]
+default['ros_buildfarm']['rpm_repos']['rhel']['9'] = %w[x86_64]
 default['ros_buildfarm']['rpm_bootstrap_urls'] = ['http://repos.ros.org/repos/$distname/ros_bootstrap/$releasever/$basearch/']
 default['ros_buildfarm']['rpm_upstream_repos']['bootstrap']['rhel']['8'] = Hash[
   architectures: %w[x86_64],
   binary: 'http://repos.ros.org/repos/rhel/ros_bootstrap/8/$basearch/',
   debug: 'http://repos.ros.org/repos/rhel/ros_bootstrap/8/$basearch/debug/',
   source: 'http://repos.ros.org/repos/rhel/ros_bootstrap/8/SRPMS/'
+]
+default['ros_buildfarm']['rpm_upstream_repos']['bootstrap']['rhel']['9'] = Hash[
+  architectures: %w[x86_64],
+  binary: 'http://repos.ros.org/repos/rhel/ros_bootstrap/9/$basearch/',
+  debug: 'http://repos.ros.org/repos/rhel/ros_bootstrap/9/$basearch/debug/',
+  source: 'http://repos.ros.org/repos/rhel/ros_bootstrap/9/SRPMS/'
 ]


### PR DESCRIPTION
This is a prerequisite for bringing up support for building RHEL 9 RPM packages on the buildfarm.

The (empty) bootstrap repository has already been created.