### PR TITLE
Only delete S.gpg-agent if it is a symlink

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -170,6 +170,7 @@ cookbook_file "/home/#{agent_username}/.gnupg/gpg.conf" do
 end
 link "/home/#{agent_username}/.gnupg/S.gpg-agent" do
   action :delete
+  only_if { ::File.symlink?("/home/#{agent_username}/.gnupg/S.gpg-agent") }
 end
 
 # Set up ssh authorized keys for publish over ssh.


### PR DESCRIPTION
This deletion reverts the use of the gpg valult for jenkins-agent that was previously implemented. If there is already a gpg-agent process running on the host when this runs, it tries and fails to remove the socket there even though it's not a symlink. If it's not a symlink, then just leave it alone.

My previous workaround for this issue was to stop the `gpg-agent` process for the `jenkins-agent` user prior to deploying.