### PR TITLE
Use cinc for test kitchen.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,15 +31,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@main
-      - name: Install Chef
+      - name: Install Cinc
         uses: actionshub/chef-install@main
+        with:
+          omnitruckUrl: omnitruck.cinc.sh
+          project: cinc-workstation
       - name: Test-Kitchen
         uses: actionshub/test-kitchen@main
         with:
           suite: ${{ matrix.suite }}
           os: 'ubuntu-2004'
         env:
-          CHEF_LICENSE: accept-no-persist
           CHEF_VERSION: ${{ matrix.chef_version }}
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
       - name: Print debug output (journalctl)

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ driver:
   vagrant
 provisioner:
   name: chef_solo
-  product_name: chef
+  product_name: cinc
   product_version: 17
   solo_rb:
     environment: test


### PR DESCRIPTION
Avoids using encumbered chef binaries which currently fail pending a license acceptance when running locally.