### PR TITLE
Comment out de-listed plugin for Windows agent support.

### DIFF
--- a/attributes/plugins.rb
+++ b/attributes/plugins.rb
@@ -101,7 +101,7 @@ default['ros_buildfarm']['jenkins']['plugins'] = {
   "translation" => "1.16",
   "trilead-api" => "1.0.13",
   "warnings-ng" => "9.0.1",
-  "windows-slaves" => "1.3.1",
+  #"windows-slaves" => "1.3.1", # Delisted https://github.com/jenkinsci/windows-slaves-plugin?tab=readme-ov-file#notice-of-deprecation
   "workflow-api" => "2.42",
   "workflow-cps" => "2.90",
   "workflow-cps-global-lib" => "2.15",


### PR DESCRIPTION
This plugin is not used by the build farm, but it is a dependency of a plugin that we do use. As a result, it may need to be vendored in order to allow the specific plugin versions we install to work correctly before we update to a version which does not have this dependency.