### PR TITLE
Add groovy script to start in shutdown mode.

### DIFF
--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -117,7 +117,7 @@ directory '/var/lib/jenkins/init.groovy.d' do
   group 'jenkins'
 end
 
-file '/var/lib/jenkins/init.groovy.d/start-quiet.groovy' do
+file '/var/lib/jenkins/init.groovy.d/03-start-quiet.groovy' do
   content <<-GROOVY
 import jenkins.model.*
 

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -112,6 +112,24 @@ node['ros_buildfarm']['jenkins']['plugins'].each do |plugin, ver|
   end
 end
 
+directory '/var/lib/jenkins/init.groovy.d' do
+  owner 'jenkins'
+  group 'jenkins'
+end
+
+file '/var/lib/jenkins/init.groovy.d/start-quiet.groovy' do
+  content <<-GROOVY
+import jenkins.model.*
+
+Jenkins.get().doQuietDown()
+  GROOVY
+
+  mode '0660'
+  owner 'jenkins'
+  group 'jenkins'
+end
+
+
 ## Jenkins configuration
 # Most of our Jenkins configuration has been consolidated into this one yaml
 # file thanks to the Jenkins configuration-as-code plugin which provides a

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -124,7 +124,7 @@ import jenkins.model.*
 Jenkins.get().doQuietDown()
   GROOVY
 
-  mode '0660'
+  mode '0500'
   owner 'jenkins'
   group 'jenkins'
 end


### PR DESCRIPTION
We've used this on each build farm for a while now but it was never part of the chef config.

This is extremely helpful in preventing jobs from running during multiple restarts for deployment updates.