### PR TITLE
Add jenkins-agent and jenkins to needrestart overrides.

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -161,6 +161,14 @@ file '/etc/jenkins-agent/token' do
   group agent_username
 end
 
+ruby_block "needrestart-config" do
+  block do
+    file = Chef::Util::FileEdit.new("/etc/needrestart/needrestart.conf")
+    file.insert_line_if_no_match(%r[\$nrconf\{override_rc\}\{qr\(\^jenkins-agent\\\.service\$\)\} = 0;], %q[$nrconf{override_rc}{qr(^jenkins-agent\.service$)} = 0;])
+    file.write_file
+  end
+end
+
 template '/etc/systemd/system/jenkins-agent.service' do
   source 'jenkins-agent.service.erb'
   variables Hash[

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -34,6 +34,14 @@ apt_update
 jdk_version = node.default['jenkins']['master']['jdk_version']
 package "openjdk-#{jdk_version}-jdk-headless"
 
+ruby_block "needrestart-config-jenkins" do
+  block do
+    file = Chef::Util::FileEdit.new("/etc/needrestart/needrestart.conf")
+    file.insert_line_if_no_match(%r[\$nrconf\{override_rc\}\{qr\(\^jenkins\\\.service\$\)\} = 0;], %q[$nrconf{override_rc}{qr(^jenkins\.service$)} = 0;])
+    file.write_file
+  end
+end
+
 # Jenkins downgrade protection
 #
 # The Jenkins package has transitioned to using systemd units instead of


### PR DESCRIPTION
needrestart in 24.04 now runs for both attended and unattended upgrades. It has a built-in list of long-running services which should not be restarted arbitrarily but need to include our jenkins-agent since it may be running jobs and shouldn't be stopped by an unattended-upgrade run.