### PR TITLE
Add a Groovy script for configuring a sensible default view.

### DIFF
--- a/files/jenkins/groovy-scripts/default-view.groovy
+++ b/files/jenkins/groovy-scripts/default-view.groovy
@@ -1,0 +1,32 @@
+import jenkins.model.*
+
+/*
+ * Create basic views and set their defaults.
+ *
+ * The ROS Build farm quickly suffers if the All view remains the default due
+ * to the large number of packaging jobs. But Views are only created after the
+ * configuration scripts are all run so they are not guaranteed to exist when
+ * Jenkins starts.
+ *
+ * The Queue view is intentionally empty (intended to easily view all queued
+ * jobs instead of only management jobs when the build queue filter is enabled)
+ * Since it's empty by design, we can create it without any additional
+ * knowledge and it can serve as a more reasonable default default than the All
+ * view. If the Manage view already exists, we can set it as the default.
+*/
+
+j = Jenkins.get()
+if (!j.getView("Queue")) {
+	queue_view = new ListView("Queue")
+	j.addView(queue_view)
+	j.save()
+}
+if (j.getPrimaryView().name == "All") {
+	manage_view = j.getView("Manage")
+	if (manage_view) {
+		j.setPrimaryView(manage_view)
+	} else {
+		j.setPrimaryView(j.getView("Queue"))
+	}
+	j.save()
+}

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -157,6 +157,13 @@ directory '/var/lib/jenkins/init.groovy.d' do
   group 'jenkins'
 end
 
+cookbook_file "/var/lib/jenkins/init.groovy.d/10-default-view.groovy" do
+  source "jenkins/groovy-scripts/default-view.groovy"
+  mode '0500'
+  owner 'jenkins'
+  group 'jenkins'
+end
+
 if node['ros_buildfarm']['jenkins']['auth_strategy'] == 'groovy'
   auth_strategy_script = data_bag_item('ros_buildfarm_jenkins_scripts', 'auth_strategy')[node.chef_environment]
   if auth_strategy_script.nil?


### PR DESCRIPTION
Here's a lil Groovy script to configure a default view.

We haven't been able to do this in chef before since views are generally created by the ros_buildfarm scripts. But the All view is soooo annoying I went looking for A Way.

If we set the default view to the Queue view, it's empty by design and present no matter what so we can create it without any context or setup normally required by ros_buildfarm. If the Manage view exists already, we set it as the default. Otherwise, we use the Queue view.