### PR TITLE
Add Hudson model import

### DIFF
--- a/files/jenkins/groovy-scripts/default-view.groovy
+++ b/files/jenkins/groovy-scripts/default-view.groovy
@@ -1,3 +1,4 @@
+import hudson.model.*
 import jenkins.model.*
 
 /*


### PR DESCRIPTION
When running the default-view script this error appears:

```
Mar 20 11:42:34 buildfarm-jenkins jenkins[13648]: org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
Mar 20 11:42:34 buildfarm-jenkins jenkins[13648]: /var/lib/jenkins/init.groovy.d/10-default-view.groovy: 20: unable to resolve class ListView
Mar 20 11:42:34 buildfarm-jenkins jenkins[13648]:  @ line 20, column 15.
Mar 20 11:42:34 buildfarm-jenkins jenkins[13648]:            queue_view = new ListView("Queue")
Mar 20 11:42:34 buildfarm-jenkins jenkins[13648]:                  ^
Mar 20 11:42:34 buildfarm-jenkins jenkins[13648]: 1 error
```

ListView class is provided by `hudson.model.ListView`