### PR TITLE
Add PrioritySorter global configuration to CASC.

### DIFF
--- a/templates/jenkins/jenkins.yaml.erb
+++ b/templates/jenkins/jenkins.yaml.erb
@@ -108,6 +108,19 @@ unclassified:
     localRepository: "default"
   pollSCM:
     pollingThreadCount: 10
+  priorityConfiguration:
+    jobGroups:
+      - jobGroupStrategy: "allJobs"
+        priority: -1
+        priorityStrategies:
+          - priorityStrategy: "jobPropertyStrategy"
+        usePriorityStrategies: true
+  prioritySorterConfiguration:
+    onlyAdminsMayEditPriorityConfiguration: true
+    strategy:
+      absoluteStrategy:
+        defaultPriority: 99
+        numberOfPriorities: 99
   timestamper:
     allPipelines: false
     elapsedTimeFormat: "'<b>'HH:mm:ss.S'</b> '"


### PR DESCRIPTION
As described in #162, this global configuration has been manually propagated from build farm to build farm but is supported by CasC since the 5.0 release (we're currently using 5.2). I tried to set this manually via the UI as a hotfix but I'm getting persistent timeouts trying to manually use the global Jenkins configuration UI. If CI passes I will also do a local run and log into Jenkins to verify that the UI configuration matches the expected CasC values.

Resolves #162.