### PR TITLE
Fix regression in dokken tests.

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,4 @@ source 'https://supermarket.chef.io'
 # Checks metadata.rb for dependencies
 metadata
 
-cookbook "jenkins", "9.5.19"
+cookbook "jenkins", git: "https://github.com/ros-infrastructure/cookbook-jenkins", branch: "latest"

--- a/files/jenkins/service/500-timeout.conf
+++ b/files/jenkins/service/500-timeout.conf
@@ -1,4 +1,5 @@
 [Service]
 TimeoutStartSec=180
 RestartSec=10s
+StartLimitBurst=10
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -17,9 +17,9 @@ provisioner:
   chef_output_format: doc
 
 platforms:
-  - name: ubuntu-20.04
+  - name: ubuntu-24.04
     driver:
-      image: dokken/ubuntu-20.04
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -9,7 +9,7 @@ provisioner:
     environment: test
 
 platforms:
-  - name: ubuntu-20.04
+  - name: ubuntu-24.04
 
 verifier:
   name: inspec

--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -168,6 +168,8 @@ ruby_block "needrestart-config" do
     file.insert_line_if_no_match(%r[\$nrconf\{override_rc\}\{qr\(\^jenkins-agent\\\.service\$\)\} = 0;], %q[$nrconf{override_rc}{qr(^jenkins-agent\.service$)} = 0;])
     file.write_file
   end
+
+  only_if { File.exist? "/etc/needrestart/needrestart.conf" }
 end
 
 template '/etc/systemd/system/jenkins-agent.service' do

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -40,6 +40,8 @@ ruby_block "needrestart-config-jenkins" do
     file.insert_line_if_no_match(%r[\$nrconf\{override_rc\}\{qr\(\^jenkins\\\.service\$\)\} = 0;], %q[$nrconf{override_rc}{qr(^jenkins\.service$)} = 0;])
     file.write_file
   end
+
+  only_if { File.exist? "/etc/needrestart/needrestart.conf" }
 end
 
 # Jenkins downgrade protection

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -96,6 +96,11 @@ include_recipe 'jenkins::jenkins'
 
 # Increase timeout of jenkins systemd unit
 # Timeout extension prevents Jenkins startup failures due to slow init scripts execution
+execute "systemctl-daemon-reload" do
+  command "systemctl daemon-reload"
+  action :nothing
+end
+
 directory '/etc/systemd/system/jenkins.service.d' do
   mode '0755'
   owner 'root'
@@ -106,11 +111,9 @@ cookbook_file '/etc/systemd/system/jenkins.service.d/500-timeout.conf' do
   source 'jenkins/service/500-timeout.conf'
   owner 'root'
   group 'root'
+  notifies :run, 'execute[systemctl-daemon-reload]', :immediately
 end
 
-execute "systemctl-daemon-reload" do
-  command "systemctl daemon-reload"
-end
 
 # Set up authentication
 chef_user = search('ros_buildfarm_jenkins_users', 'chef_user:true').first


### PR DESCRIPTION
This addition fails in the dokken builds where needrestart isn't
installed by default. We don't _rely_ in it being present but we do want
to add our configuration if it is. So I've scoped these blocks with an
only-if.
