### PR TITLE
Add openjdk- as unatteded upgrades blacklist

### DIFF
--- a/attributes/agent.rb
+++ b/attributes/agent.rb
@@ -34,4 +34,4 @@ default['ros_buildfarm']['agent']['labels'] = %w(buildagent)
 default['ros_buildfarm']['agent']['jdk_version'] = 21
 
 # Prevents docker and containerd from getting updates and restarting mid build. See https://github.com/ros2/ci/issues/702
-default['ros_buildfarm']['unattended_upgrades']['package_blacklist'] = %w[docker.io containerd]
+default['ros_buildfarm']['unattended_upgrades']['package_blacklist'] = %w[docker.io containerd openjdk-]


### PR DESCRIPTION
This is a mitigation to prevent https://github.com/osrf/buildfarm-tools/issues/189#issuecomment-3596997307 from happening again