### PR TITLE
Security mitigations for Dirty Frag

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -1,3 +1,5 @@
+include_recipe 'ros_buildfarm::security-patches'
+
 apt_update
 package 'docker.io'
 

--- a/recipes/security-patches.rb
+++ b/recipes/security-patches.rb
@@ -1,0 +1,21 @@
+# Mitigate CVE-2026-43284 and CVE-2026-43500 (Dirty Frag)
+# https://ubuntu.com/blog/dirty-frag-linux-vulnerability-fixes-available
+# Blocks esp4, esp6, and rxrpc kernel modules until a patched kernel is deployed.
+file '/etc/modprobe.d/dirty-frag.conf' do
+  content <<~EOF
+    install esp4 /bin/false
+    install esp6 /bin/false
+    install rxrpc /bin/false
+  EOF
+  mode '0644'
+  owner 'root'
+  group 'root'
+end
+
+%w[esp4 esp6 rxrpc].each do |mod|
+  execute "rmmod-#{mod}" do
+    command "rmmod #{mod}"
+    only_if "lsmod | grep -q ^#{mod}"
+    ignore_failure true # avoid error on failure since it fails if it's used by an application
+  end
+end


### PR DESCRIPTION
Dirty Frag is a Linux kernel vulnerability (CVE-2026-43284 / CVE-2026-43500) affecting how certain kernel modules handle memory fragmentation.

Affected modules:

esp4 / esp6 — IPsec Encapsulating Security Protocol
rxrpc — Andrew File System (AFS) protocol
Severity: CVE-2026-43284 scores 8.8 (High), CVE-2026-43500 scores 7.8 (High)

Impact: Affects all Ubuntu releases from 14.04 LTS through 26.04 LTS.

This PR applies mitigations recommended on https://ubuntu.com/blog/dirty-frag-linux-vulnerability-fixes-available to linux agents on build.ros2.

This PR should be reverted once a kernel patch for this vulnerability is available. 

### Generative AI disclosure

This PR was assisted-by Claude Sonnet 4.6, I have reviewed the changes and  modified accordingly. 
