### PR TITLE
Add Resolute, Bullseye and Trixie to repo agent

### DIFF
--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -9,7 +9,7 @@ default['ros_buildfarm']['apt_repos']['component'] = 'main'
 default['ros_buildfarm']['apt_repos']['architectures'] = %w[i386 amd64 arm64 armhf source]
 
 # The list of Debian and Ubuntu distributions supported by your build farm.
-default['ros_buildfarm']['apt_repos']['suites'] = %w[xenial bionic focal stretch buster noble]
+default['ros_buildfarm']['apt_repos']['suites'] = %w[xenial bionic focal stretch buster noble resolute]
 
 # The official buildfarm provides rsync endpoints to allow syncing between mirrors.
 # Endpoints are defined in a nested hash structure with an example below

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -9,7 +9,7 @@ default['ros_buildfarm']['apt_repos']['component'] = 'main'
 default['ros_buildfarm']['apt_repos']['architectures'] = %w[i386 amd64 arm64 armhf source]
 
 # The list of Debian and Ubuntu distributions supported by your build farm.
-default['ros_buildfarm']['apt_repos']['suites'] = %w[xenial bionic focal stretch buster noble resolute]
+default['ros_buildfarm']['apt_repos']['suites'] = %w[xenial bionic focal stretch buster noble resolute bullseye trixie]
 
 # The official buildfarm provides rsync endpoints to allow syncing between mirrors.
 # Endpoints are defined in a nested hash structure with an example below


### PR DESCRIPTION
This is deployed on repo.test.ros2.org, and was tested there (Resolute only)