### PR TITLE
Remove redundant Jenkins downgrade guard, now handled by `jenkins::jenkins`

### DIFF
--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -42,54 +42,10 @@ ruby_block "needrestart-config-jenkins" do
   end
 end
 
-# Jenkins downgrade protection
-#
-# The Jenkins package has transitioned to using systemd units instead of
-# sysvinit style init scripts. In order to maintain this cookbook the last
-# version of Jenkins which is packaged with a sysvinit script is pinned.
-# However Jenkins cannot be safely downgraded and some configurations of
-# Jenkins will continue to function once initially configured even after the
-# systemd switch.
-# To protect users from unintentional downgrades we're going to do something really ugly here.
-package 'jenkins' do
-  action :lock
-  only_if { -> do
-    jenkins_info = `dpkg -s jenkins`
-    if $?.exitstatus != 0
-       return false
-    end
-
-    version_line = jenkins_info.lines.select{|line| line =~ /^Version: /}.first
-    if version_line.nil?
-      Chef::Log.fatal("Could not determine Jenkins version from dpkg but it does seem installed.")
-      raise
-    end
-
-    # Transform "Version: 2.319.1\n" to ["2", "319", "1"]
-    version_components = version_line.chomp.split(": ")[1].split(".")
-    # The first systemd versions are 2.335 (weekly) and 2.332.1 (LTS)
-    if version_components[0].to_i > 2 or version_components[1].to_i >= 332
-      node.run_state[:jenkins_package_version_lock] = version_components.join('.')
-      Chef::Log.warn("Chef detected this Jenkins version: #{node.run_state[:jenkins_package_version_lock]}")
-      return true
-    end
-    # Jenkins is installed but is older than the maximum and can be upgraded.
-    return false
-  end.call }
-end
-
-ruby_block 'prevent jenkins downgrade' do
-  block do
-    if node.run_state[:jenkins_package_version_lock]
-      if node['jenkins']['master']['version'] != node.run_state[:jenkins_package_version_lock]
-        Chef::Log.fatal("Before this cookbook continues, please set the node['jenkins']['master']['version'] attribute to #{node.run_state[:jenkins_package_version_lock]} or this cookbook will attempt to downgrade your Jenkins version.")
-        Chef::Log.fatal("See https://github.com/ros-infrastructure/cookbook-ros-buildfarm/issues/121 for more information")
-        raise
-      end
-    end
-  end
-end
-
+# Jenkins downgrade protection is handled by jenkins::jenkins itself, driven
+# by the node['jenkins']['master']['version'] attribute: leave it unset to
+# always install the newest package, or pin it to control the installed
+# version. See cookbooks/jenkins/recipes/jenkins.rb.
 include_recipe 'jenkins::jenkins'
 
 # Increase timeout of jenkins systemd unit


### PR DESCRIPTION
# Description

Depends on https://github.com/ros-infrastructure/cookbook-jenkins/pull/13, which implements this guard generically at the point where the package "jenkins" resource actually lives. 

This PR removes the usage of `package 'jenkins'` to leave all the tasks to the `jenkins` cookbook. This means the downgrade protection is now provided directly by that cookbook using the `node['jenkins']['master']['version']` attribute