### PR TITLE
Move CI to ubuntu 24.04 and chef 19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,3 @@
----
 name: ci
 
 # yamllint disable-line rule:truthy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           - 'jenkins'
         chef_version:
           - '17'
+          - '19'
       fail-fast: false
     steps:
       - name: Check out code
@@ -40,7 +41,9 @@ jobs:
         uses: actionshub/test-kitchen@main
         with:
           suite: ${{ matrix.suite }}
-          os: 'ubuntu-2004'
+          os:
+            - 'ubuntu-2004'
+            - 'ubuntu-2404'
         env:
           CHEF_VERSION: ${{ matrix.chef_version }}
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,6 @@ jobs:
           - '17'
           - '19'
         os:
-          - 'ubuntu-2004'
           - 'ubuntu-2404'
       fail-fast: false
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,10 @@ jobs:
           - 'jenkins'
         chef_version:
           - '17'
+          - '19'
+        os:
+          - 'ubuntu-2004'
+          - 'ubuntu-2404'
       fail-fast: false
     steps:
       - name: Check out code
@@ -39,7 +43,7 @@ jobs:
         uses: actionshub/test-kitchen@main
         with:
           suite: ${{ matrix.suite }}
-          os: 'ubuntu-2004'
+          os: ${{ matrix.os }}
         env:
           CHEF_VERSION: ${{ matrix.chef_version }}
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
           - 'jenkins'
         chef_version:
           - '17'
-          - '19'
       fail-fast: false
     steps:
       - name: Check out code
@@ -40,9 +39,7 @@ jobs:
         uses: actionshub/test-kitchen@main
         with:
           suite: ${{ matrix.suite }}
-          os:
-            - 'ubuntu-2004'
-            - 'ubuntu-2404'
+          os: 'ubuntu-2004'
         env:
           CHEF_VERSION: ${{ matrix.chef_version }}
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -27,6 +27,13 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install -y needrestart
+  - name: ubuntu-24.04
+    driver:
+      image: dokken/ubuntu-24.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install -y needrestart
 
 verifier:
   name: inspec

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -20,13 +20,6 @@ provisioner:
     environment: test
 
 platforms:
-  - name: ubuntu-20.04
-    driver:
-      image: dokken/ubuntu-20.04
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-        - RUN /usr/bin/apt-get install -y needrestart
   - name: ubuntu-24.04
     driver:
       image: dokken/ubuntu-24.04

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: dokken
-  chef_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || '19' %>
   use_sudo: false
   chef_image: cincproject/cinc
   privileged: true
@@ -16,6 +16,8 @@ provisioner:
   chef_binary: /opt/cinc/bin/cinc-solo
   chef_log_level: debug
   chef_output_format: doc
+  # enforce_idempotency: true
+  # multiple_converge: 2
   client_rb:
     environment: test
 
@@ -23,6 +25,13 @@ platforms:
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install -y needrestart
+  - name: ubuntu-24.04
+    driver:
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
@@ -46,7 +55,6 @@ suites:
       ros_buildfarm:
         smtp: true
     run_list:
-      - recipe[ros_buildfarm::agent]
       - recipe[ros_buildfarm::jenkins]
     verifier:
       inspec_tests:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,7 +1,7 @@
 ---
 driver:
   name: dokken
-  chef_version: <%= ENV['CHEF_VERSION'] || '19' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   use_sudo: false
   chef_image: cincproject/cinc
   privileged: true
@@ -16,8 +16,6 @@ provisioner:
   chef_binary: /opt/cinc/bin/cinc-solo
   chef_log_level: debug
   chef_output_format: doc
-  # enforce_idempotency: true
-  # multiple_converge: 2
   client_rb:
     environment: test
 
@@ -25,13 +23,6 @@ platforms:
   - name: ubuntu-20.04
     driver:
       image: dokken/ubuntu-20.04
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-        - RUN /usr/bin/apt-get install -y needrestart
-  - name: ubuntu-24.04
-    driver:
-      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
@@ -55,6 +46,7 @@ suites:
       ros_buildfarm:
         smtp: true
     run_list:
+      - recipe[ros_buildfarm::agent]
       - recipe[ros_buildfarm::jenkins]
     verifier:
       inspec_tests:

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -234,7 +234,7 @@ elsif node.default['ros_buildfarm']['jenkins']['auth_strategy'] == 'default'
       }
       password = hudson.security.HudsonPrivateSecurityRealm.Details.fromPlainPassword("#{user['password']}")
       user.addProperty(password)
-      keys = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl(#{user['public_keys'].join('\n')})
+      keys = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl("""#{user['public_keys'].join("\n")}""")
       user.addProperty(keys)
       user.save()
     GROOVY

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -108,7 +108,7 @@ template '/var/lib/jenkins/jenkins.yaml' do
     server_name: node['ros_buildfarm']['jenkins']['server_name'],
     admin_email: node['ros_buildfarm']['jenkins']['admin_email'],
   ]
-  notifies :restart, 'service[jenkins]', :immediately
+  notifies :restart, 'service[jenkins]', :delayed
 end
 
 ## Configuration for the publish-over-ssh plugin.
@@ -140,7 +140,7 @@ template '/var/lib/jenkins/jenkins.plugins.publish_over_ssh.BapSshPublisherPlugi
     plugin_version: node['ros_buildfarm']['jenkins']['plugins']['publish-over-ssh'],
     ssh_key: data_bag_item('ros_buildfarm_publish_over_ssh_key', node.chef_environment)['private_key']
   ]
-  notifies :restart, 'service[jenkins]', :immediately
+  notifies :restart, 'service[jenkins]', :delayed
 end
 
 # Jenkins authentication.


### PR DESCRIPTION
# Description

This PR updates our test infrastructure to match the Ubuntu 24.04 platform and test and Chef 19, it also fixes a string interpolation issue in the Jenkins Groovy script, and optimizes service restart behavior during chef runs

## Changes
- Updated Test Kitchen configuration and CI Workflow from Ubuntu 20.04 to Ubuntu 24.04. Added Chef 19 to the matrix suite
- Changed service restart notifications for configuration file updates from `:immediately` to `:delayed`. This prevents multiple abrupt service restarts during a single run, allowing Chef to converge before restarting Jenkins. (Part of #177)
- Fixed multiline SSH public key interpolation in the Groovy user setup and correct double-quote escaping for "`\n`"

> [!NOTE]
>
> Note that we won't run jenkins CI on 20.04 from now on
