### PR TITLE
Double the agent disk space thresholds

### DIFF
--- a/templates/jenkins/jenkins.yaml.erb
+++ b/templates/jenkins/jenkins.yaml.erb
@@ -4,6 +4,10 @@ jenkins:
     rawHtml:
       disableSyntaxHighlighting: false
   mode: NORMAL
+  nodeMonitors:
+  - diskSpace:
+      freeSpaceThreshold: 20G
+      freeSpaceWarningThreshold: 40G
   numExecutors: 1
   projectNamingStrategy: "standard"
   quietPeriod: 5


### PR DESCRIPTION
We're getting a LOT of disk space issues now that our agents are living longer. When they fill up, they should be taken out of circulation and NOT just sit there and fail builds.

https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/demos/node-monitors/README.md