### PR TITLE
Add anubis support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
           - 'agent'
           - 'repo'
           - 'jenkins'
+          - 'jenkins-anubis'
         chef_version:
           - '19'
         os:
@@ -53,14 +54,14 @@ jobs:
                 ${{ matrix.suite }}-${{ matrix.os }} \
                 -c "journalctl -l"
       - name: Print debug output on failure (jenkins.log)
-        if: failure() && matrix.suite == 'jenkins'
+        if: failure() && startsWith(matrix.suite, 'jenkins')
         run: |
             set -x
             KITCHEN_LOCAL_YAML=kitchen.dokken.yml /usr/bin/kitchen exec \
                 ${{ matrix.suite }}-${{ matrix.os }} \
                 -c "cat /var/log/jenkins/jenkins.log"
       - name: Print debug output on failure (systemctl jenkins status)
-        if: failure() && matrix.suite == 'jenkins'
+        if: failure() && startsWith(matrix.suite, 'jenkins')
         run: |
             set -x
             KITCHEN_LOCAL_YAML=kitchen.dokken.yml /usr/bin/kitchen exec \

--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -25,3 +25,7 @@ default['jenkins']['master']['version'] = '2.555.3'
 
 # JDK version to install
 default['jenkins']['master']['jdk_version'] = 21
+
+# Flag to enable/disable Anubis 
+# This only configures nginx assuming Anubis is running as a systemd unit named anubis@jenkins
+default['jenkins']['anubis'] = false

--- a/attributes/jenkins.rb
+++ b/attributes/jenkins.rb
@@ -29,3 +29,6 @@ default['jenkins']['master']['jdk_version'] = 21
 # Flag to enable/disable Anubis 
 # This only configures nginx assuming Anubis is running as a systemd unit named anubis@jenkins
 default['jenkins']['anubis'] = false
+# Flag to enable/disable Anubis 
+# This only configures nginx assuming Anubis is running as a systemd unit named anubis@jenkins
+default['anubis']['socket'] = ''

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -51,6 +51,19 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/jenkins
+  - name: jenkins-anubis
+    data_bags_path: "test/integration/data_bags"
+    attributes:
+      ros_buildfarm:
+        letsencrypt_enabled: true
+      jenkins:
+        anubis: true
+    run_list:
+      - recipe[ros_buildfarm::agent]
+      - recipe[ros_buildfarm::jenkins]
+    verifier:
+      inspec_tests:
+        - test/integration/jenkins-anubis
   - name: repo
     data_bags_path: "test/integration/data_bags"
     run_list:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -36,6 +36,19 @@ suites:
     verifier:
       inspec_tests:
         - test/integration/jenkins
+  - name: jenkins-anubis
+    data_bags_path: "test/integration/data_bags"
+    attributes:
+      ros_buildfarm:
+        letsencrypt_enabled: true
+      jenkins:
+        anubis: true
+
+    run_list:
+      - recipe[ros_buildfarm::jenkins]
+    verifier:
+      inspec_tests:
+        - test/integration/jenkins-anubis
   - name: repo
     attributes:
       docker:

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -273,23 +273,38 @@ timezone node['ros_buildfarm']['jenkins']['timezone']
 
 # Anubis is not installed or managed by this cookbook, it is expected to
 # already be running as the anubis@<instance> systemd unit. Refuse to render a
-# proxy configuration pointing at a socket nothing is listening on. 
-if node['jenkins']['anubis'] && node.chef_environment != 'test'
-  require 'socket'
+# proxy configuration pointing at a socket nothing is listening on.
+#
+# This is a ruby_block rather than inline recipe code because chef compiles the
+# whole run_list before converging any of it. Inline code runs during the
+# compile phase, so a recipe earlier in the run_list which starts Anubis has
+# only been compiled by then and has not started anything yet. As a resource
+# this runs in converge order, after those recipes have done their work and
+# before the nginx configuration below is written.
+ruby_block 'verify anubis is accepting connections' do
+  block do
+    require 'socket'
 
-  # Anubis runs as the systemd template unit anubis@<instance>, which keeps its
-  # listening socket in /run/anubis/<instance>/instance.sock. This is the path
-  # the nginx template proxies to, so the unit name is derived from it rather
-  # than spelled out twice.
-  anubis_socket = node['anubis']['socket']
-  anubis_unit = "anubis@#{::File.basename(::File.dirname(anubis_socket))}"
+    anubis_socket = node['anubis']['socket'].to_s
+    if anubis_socket.empty?
+      raise "node['jenkins']['anubis'] is enabled but node['anubis']['socket'] is not set. " \
+        "Set it to the listening socket of the Anubis instance in front of Jenkins."
+    end
 
-  begin
-    ::UNIXSocket.new(anubis_socket).close
-  rescue SystemCallError => e
-    raise "node['jenkins']['anubis'] is enabled but nothing is accepting connections on " \
-      "#{anubis_socket} (#{e.class}). Start #{anubis_unit} or set node['jenkins']['anubis'] = false."
+    # Anubis runs as the systemd template unit anubis@<instance>, which keeps
+    # its listening socket in /run/anubis/<instance>/instance.sock. This is the
+    # path the nginx template proxies to, so the unit name is derived from it
+    # rather than spelled out twice.
+    anubis_unit = "anubis@#{::File.basename(::File.dirname(anubis_socket))}"
+
+    begin
+      ::UNIXSocket.new(anubis_socket).close
+    rescue SystemCallError => e
+      raise "node['jenkins']['anubis'] is enabled but nothing is accepting connections on " \
+        "#{anubis_socket} (#{e.class}). Start #{anubis_unit} or set node['jenkins']['anubis'] = false."
+    end
   end
+  only_if { node['jenkins']['anubis'] && node.chef_environment != 'test' }
 end
 
 package 'nginx'

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -270,6 +270,25 @@ end
 timezone node['ros_buildfarm']['jenkins']['timezone']
 
 ## Configure web proxy ##
+
+# Anubis is not installed or managed by this cookbook, it is expected to
+# already be running as the anubis@jenkins systemd unit. Refuse to render a
+# proxy configuration pointing at a socket nothing is listening on rather than
+# leaning on the upstream's backup server to hide the misconfiguration.
+if node['jenkins']['anubis'] && node.chef_environment != 'test'
+  anubis_socket = '/run/anubis/jenkins/instance.sock'
+
+  unless shell_out('systemctl is-active --quiet anubis@jenkins').exitstatus.zero?
+    raise "node['jenkins']['anubis'] is enabled but the anubis@jenkins service is not running. " \
+      "Start the service or set node['jenkins']['anubis'] = false."
+  end
+
+  unless ::File.socket?(anubis_socket)
+    raise "node['jenkins']['anubis'] is enabled but #{anubis_socket} is not a socket. " \
+      "The nginx configuration proxies to that path, check the Anubis instance configuration."
+  end
+end
+
 package 'nginx'
 service 'nginx' do
   action [ :enable, :start]

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -272,20 +272,23 @@ timezone node['ros_buildfarm']['jenkins']['timezone']
 ## Configure web proxy ##
 
 # Anubis is not installed or managed by this cookbook, it is expected to
-# already be running as the anubis@jenkins systemd unit. Refuse to render a
-# proxy configuration pointing at a socket nothing is listening on rather than
-# leaning on the upstream's backup server to hide the misconfiguration.
+# already be running as the anubis@<instance> systemd unit. Refuse to render a
+# proxy configuration pointing at a socket nothing is listening on. 
 if node['jenkins']['anubis'] && node.chef_environment != 'test'
-  anubis_socket = '/run/anubis/jenkins/instance.sock'
+  require 'socket'
 
-  unless shell_out('systemctl is-active --quiet anubis@jenkins').exitstatus.zero?
-    raise "node['jenkins']['anubis'] is enabled but the anubis@jenkins service is not running. " \
-      "Start the service or set node['jenkins']['anubis'] = false."
-  end
+  # Anubis runs as the systemd template unit anubis@<instance>, which keeps its
+  # listening socket in /run/anubis/<instance>/instance.sock. This is the path
+  # the nginx template proxies to, so the unit name is derived from it rather
+  # than spelled out twice.
+  anubis_socket = node['anubis']['socket']
+  anubis_unit = "anubis@#{::File.basename(::File.dirname(anubis_socket))}"
 
-  unless ::File.socket?(anubis_socket)
-    raise "node['jenkins']['anubis'] is enabled but #{anubis_socket} is not a socket. " \
-      "The nginx configuration proxies to that path, check the Anubis instance configuration."
+  begin
+    ::UNIXSocket.new(anubis_socket).close
+  rescue SystemCallError => e
+    raise "node['jenkins']['anubis'] is enabled but nothing is accepting connections on " \
+      "#{anubis_socket} (#{e.class}). Start #{anubis_unit} or set node['jenkins']['anubis'] = false."
   end
 end
 

--- a/recipes/jenkins.rb
+++ b/recipes/jenkins.rb
@@ -326,6 +326,10 @@ if node['ros_buildfarm']['letsencrypt_enabled']
       File.directory?("/root/.acme.sh/#{server_name}_ecc") and
       File.read("/root/.acme.sh/#{server_name}_ecc/#{server_name}.conf").match(/Le_ReloadCmd='__ACME_BASE64__START_L3Jvb3QvY2VydC11cGRhdGUtaG9vay5zaA==__ACME_BASE64__END_'/)
     }
+    # Test Kitchen instances have no publicly resolvable domain so the ACME
+    # challenge can never succeed there. The bootstrap self-signed certificate
+    # written above is enough to bring nginx up for the integration tests.
+    not_if { node.chef_environment == 'test' }
   end
 else
   template '/etc/nginx/sites-enabled/jenkins' do

--- a/templates/nginx/jenkins-webproxy.ssl.conf.erb
+++ b/templates/nginx/jenkins-webproxy.ssl.conf.erb
@@ -7,6 +7,17 @@ upstream jenkins {
 	server 127.0.0.1:8080 fail_timeout=0;
 }
 
+# Configure Anubis Upstream
+# It's expected to be running as anubis@jenkins systemd unit
+<% if (node['jenkins']['anubis']) %>
+upstream anubis {
+	server unix:/run/anubis/jenkins/instance.sock fail_timeout=0;
+  # Fallback to serving through nginx to avoid downtime if anubis is down
+  server 127.0.0.1:8080 backup;
+}
+<% end -%>
+
+
 # HTTP server is used just for ACME challenge and allowing build status icon
 # links that are already in the wild to be accepted. Otherwise redirect to
 # HTTPS
@@ -43,8 +54,8 @@ server {
 
 	ssl_certificate <%= @cert_path %>;
 	ssl_certificate_key <%= @key_path %>;
-        # Pass through jenkins headers nginx may consider invalid.
-        ignore_invalid_headers off;
+  # Pass through jenkins headers nginx may consider invalid.
+  ignore_invalid_headers off;
 
 	# Allow ACME challenge to access the webroot directly.
 	location '/.well-known/acme-challenge' {
@@ -58,6 +69,68 @@ server {
 		root /dev/null;
 		deny all;
 	}
+
+  # Mitigate ghprb SECURITY-2789 (CVE-2023-24434/-24435/-24436) — no upstream fix.
+  # Blocks the credential-enumeration + connection-test form-validation endpoints.
+  # see https://github.com/osrf/chef-osrf/issues/367
+  location ~* "/descriptorByName/org\.jenkinsci\.plugins\.ghprb\." {
+      return 403;
+      access_log /var/log/nginx/ghprb_blocked.log;
+  }
+  
+# API endpoints help bots identify how to query the buildfarm
+  # There is no usual usage of them by the dev team so we should disable them
+  location ~* /api/(xml|json|python|schema)(/|$) {
+      return 503;
+  }
+# Configure endpoints that are passed to Anubis
+# If you need an endpoint to not be challenged by Anubis put it above this 
+# since nginx evaluates sequentially it will otherwise be overwritten by anubis
+<% if (node['jenkins']['anubis']) %>
+  # Serve Anubis images
+  location ^~ /.within.website/ {
+    proxy_set_header Host $host:$server_port;
+    proxy_set_header X-Real-Ip $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_redirect http:// https://;
+    proxy_buffering off;
+    proxy_pass http://anubis;
+  }
+  # Anubis proxied endpoints
+  location ~* /securityRealm(/|$)  {
+    proxy_set_header Host $host:$server_port;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_redirect http:// https://;
+    proxy_buffering off;
+    proxy_pass http://anubis;
+  }  
+  location ~* /testReport(/|$)  {
+    proxy_set_header Host $host:$server_port;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_redirect http:// https://;
+    proxy_buffering off;
+    proxy_pass http://anubis;
+  }
+
+  # Build console output and the progressive log endpoints the console page
+  # polls while a build is running.
+  location ~* /(console(Text|Full)?|logText/progressive(Text|Html))(/|$) {
+    proxy_set_header Host $host:$server_port;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_redirect http:// https://;
+    proxy_buffering off;
+    proxy_pass http://anubis;
+  }
+
+<% end -%>
 
 	location / {
 		# https://www.jenkins.io/doc/book/system-administration/reverse-proxy-configuration-nginx/

--- a/test/integration/jenkins-anubis/anubis_test.rb
+++ b/test/integration/jenkins-anubis/anubis_test.rb
@@ -2,6 +2,11 @@
 # templates/nginx/jenkins-webproxy.ssl.conf.erb when node['jenkins']['anubis']
 # is enabled. The suite runs with letsencrypt_enabled so that the SSL template
 # (the only one carrying the Anubis configuration) is the one installed.
+#
+# Anubis itself is never installed here, the cookbook does not manage it. The
+# recipe's guard against the flag being enabled without a running anubis@jenkins
+# unit is skipped in the 'test' chef environment for that reason, so these tests
+# cover the rendered configuration rather than a live Anubis instance.
 
 jenkins_site = '/etc/nginx/sites-enabled/jenkins'
 

--- a/test/integration/jenkins-anubis/anubis_test.rb
+++ b/test/integration/jenkins-anubis/anubis_test.rb
@@ -1,0 +1,47 @@
+# Verifies the Anubis nginx configuration rendered by
+# templates/nginx/jenkins-webproxy.ssl.conf.erb when node['jenkins']['anubis']
+# is enabled. The suite runs with letsencrypt_enabled so that the SSL template
+# (the only one carrying the Anubis configuration) is the one installed.
+
+jenkins_site = '/etc/nginx/sites-enabled/jenkins'
+
+# Endpoints which are expected to be challenged by Anubis. The keys are used
+# for the test descriptions, the values are the location matchers as rendered
+# into the nginx configuration.
+anubis_locations = {
+  'Anubis static assets' => 'location ^~ /.within.website/',
+  'securityRealm' => 'location ~* /securityRealm(/|$)',
+  'testReport' => 'location ~* /testReport(/|$)',
+  'build console output' => 'location ~* /(console(Text|Full)?|logText/progressive(Text|Html))(/|$)',
+}
+
+describe service 'nginx' do
+  it { should be_running }
+end
+
+describe file jenkins_site do
+  it { should exist }
+
+  # The Anubis upstream is served by the anubis@jenkins systemd unit over a
+  # unix socket and falls back to Jenkins directly if Anubis is unavailable.
+  its('content') { should match(/upstream anubis \{/) }
+  its('content') { should match(%r{server unix:/run/anubis/jenkins/instance\.sock fail_timeout=0;}) }
+  its('content') { should match(/server 127\.0\.0\.1:8080 backup;/) }
+
+  anubis_locations.each do |name, location|
+    it "proxies #{name} to the anubis upstream" do
+      block = subject.content[/#{Regexp.escape(location)}.*?\n  \}/m]
+      expect(block).not_to be_nil, "no #{location.inspect} block in #{jenkins_site}"
+      expect(block).to match(%r{proxy_pass http://anubis;})
+      expect(block).to match(/proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;/)
+    end
+  end
+
+  # Everything which is not explicitly handed to Anubis must still be proxied
+  # straight to Jenkins.
+  its('content') { should match(%r[location / \{[^}]*proxy_pass http://jenkins;]m) }
+end
+
+describe command 'nginx -t' do
+  its('exit_status') { should eq 0 }
+end

--- a/test/integration/jenkins/jenkins_test.rb
+++ b/test/integration/jenkins/jenkins_test.rb
@@ -5,3 +5,11 @@ end
 describe service 'nginx' do
   it { should be_running }
 end
+
+# Anubis is opt-in via node['jenkins']['anubis'], see the jenkins-anubis suite
+# for the enabled case. Match on the directives rather than the word 'anubis'
+# because the SSL template carries the Anubis comments unconditionally.
+describe file '/etc/nginx/sites-enabled/jenkins' do
+  its('content') { should_not match(/upstream anubis \{/) }
+  its('content') { should_not match(%r{proxy_pass http://anubis;}) }
+end


### PR DESCRIPTION
This PR adds Anubis support to the jenkins manager behind a feature flag on the cookbook attributes
https://github.com/ros-infrastructure/cookbook-ros-buildfarm/blob/5732ae35d5b40fb85fc7b4d7aee9a4a0d515d59c/attributes/jenkins.rb#L29-L31

### Implementation notes 
- Anubis is expected to be installed on the system, this cookbook does not install or configures it. 
- Furthermore Anubis is expected to be running when the jenkins recipe runs. 
- Anubis is expected to be running at the value defined at `node['anubis']['socket']'
- A guard will fail the recipe if the attribute is set but Anubis is not running. 
- The test on this cookbook don't exercise/validate the Anubis proxy it only checks that nginx correctly forwards the expected endpoints to anubis. 

Two extra nginx improvements are bundled in ported from config at build.o.o:

https://github.com/ros-infrastructure/cookbook-ros-buildfarm/blob/cc22afe94c1741a0606dae06699cad422743073e/templates/nginx/jenkins-webproxy.ssl.conf.erb#L73-L85 